### PR TITLE
Tags fix

### DIFF
--- a/api/models/item.js
+++ b/api/models/item.js
@@ -50,7 +50,6 @@ async function getMany(user, conditions, permissionsRequired=perms.READ, basicOn
       LEFT JOIN item as child_item ON child_item.id = lineage_child.child_id
       LEFT JOIN item as parent_item ON parent_item.id = lineage_parent.parent_id
     `;
-    // LEFT JOIN tag ON tag.item_id = item.id
     const queryString = `
       SELECT
         item.id,

--- a/api/models/item.js
+++ b/api/models/item.js
@@ -50,8 +50,9 @@ async function getMany(user, conditions, permissionsRequired=perms.READ, basicOn
       LEFT JOIN item as child_item ON child_item.id = lineage_child.child_id
       LEFT JOIN item as parent_item ON parent_item.id = lineage_parent.parent_id
     `;
+    // LEFT JOIN tag ON tag.item_id = item.id
     const queryString = `
-      SELECT 
+      SELECT
         item.id,
         item.title,
         item.shortname,
@@ -61,12 +62,16 @@ async function getMany(user, conditions, permissionsRequired=perms.READ, basicOn
         user.username as author,
         universe.title as universe,
         ${selectString}
-        JSON_ARRAYAGG(tag) as tags
+        tag.tags
       FROM item
       INNER JOIN user ON user.id = item.author_id
       INNER JOIN universe ON universe.id = item.universe_id
       INNER JOIN authoruniverse as au_filter ON universe.id = au_filter.universe_id AND (universe.public = 1${usrQueryString})
-      LEFT JOIN tag ON tag.item_id = item.id
+      LEFT JOIN (
+        SELECT item_id, JSON_ARRAYAGG(tag) as tags
+        FROM tag
+        GROUP BY item_id
+      ) tag ON tag.item_id = item.id
       ${joinString}
       ${conditionString}
       GROUP BY 

--- a/api/models/item.js
+++ b/api/models/item.js
@@ -200,7 +200,7 @@ async function put(user, universeShortname, itemShortname, changes) {
     // If tags list is provided, we can just as well handle it here
     putTags(user, universeShortname, itemShortname, tags);
     const tagLookup = {};
-    item.tags.forEach(tag => {
+    item.tags?.forEach(tag => {
       tagLookup[tag] = true;
     });
     tags.forEach(tag => {
@@ -259,7 +259,7 @@ async function putTags(user, universeShortname, itemShortname, tags) {
   if (!item) return [code];
   try {
     const tagLookup = {};
-    item.tags.forEach(tag => {
+    item.tags?.forEach(tag => {
       tagLookup[tag] = true;
     });
     const valueString = tags.filter(tag => !tagLookup[tag]).map(tag => `(${item.id}, "${tag}")`).join(',');

--- a/templates/edit/item.pug
+++ b/templates/edit/item.pug
@@ -15,7 +15,7 @@ block content
 
     div.inputGroup
       label( for='tags' ) Tags: 
-      textarea( id='tags' name='tags' ) #{item.tags.join(' ')}
+      textarea( id='tags' name='tags' ) #{(item.tags || []).join(' ')}
 
     div#body.editor( data-replicated-value=item.obj_data.body || '' )
       if 'body' in item.obj_data

--- a/templates/list/universeItems.pug
+++ b/templates/list/universeItems.pug
@@ -68,6 +68,6 @@ block content
           td.nowrap( data-sort=item.created_at ) #{formatDate(item.created_at)}
           td.nowrap( data-sort=item.updated_at ) #{formatDate(item.updated_at)}
           td
-            each itemTag in item.tags
-              if itemTag
+            if item.tags
+              each itemTag in item.tags
                 a.link.link-animated( class={ 'link-selected': itemTag == tag } onclick=`filterByTag('${itemTag}')` ) ##{itemTag} 

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -14,8 +14,9 @@ block content
       |  - Last updated #{formatDate(new Date(item.updated_at))}
   p.center
     small
-      each tag in item.tags
-        | ##{tag} 
+      if item.tags
+        each tag in item.tags
+          | ##{tag} 
   hr
 
   if 'tabs' in item.obj_data


### PR DESCRIPTION
Fixed tags repeating once for every author in a universe if universe is public. This just so happened to also fix another annoyance, namely that an item with no tags would have an empty string in its tags list - now the tags list will be null if there are no tags instead. An empty list would probably be preferable, but this is clearly better.