### PR TITLE
Update Homepage

### DIFF
--- a/api/models/universe.js
+++ b/api/models/universe.js
@@ -27,17 +27,22 @@ async function getMany(user, conditions, permissionLevel=perms.READ) {
     const queryString = `
       SELECT 
         universe.*,
-        JSON_OBJECTAGG(user.id, user.username) as authors,
-        JSON_OBJECTAGG(user.id, au.permission_level) as author_permissions,
-        owner.username as owner
+        JSON_OBJECTAGG(author.id, author.username) AS authors,
+        JSON_OBJECTAGG(author.id, au.permission_level) AS author_permissions,
+        owner.username AS owner,
+        JSON_REMOVE(JSON_OBJECTAGG(
+          IFNULL(fu.user_id, 'null__'),
+          fu.is_following
+        ), '$.null__') AS followers
       FROM universe
-      INNER JOIN authoruniverse as au_filter
+      INNER JOIN authoruniverse AS au_filter
         ON universe.id = au_filter.universe_id AND (
           ${permsQueryString}
         )
-      LEFT JOIN authoruniverse as au ON universe.id = au.universe_id
-      LEFT JOIN user ON user.id = au.user_id
-      INNER JOIN user as owner ON universe.author_id = owner.id
+      LEFT JOIN authoruniverse AS au ON universe.id = au.universe_id
+      LEFT JOIN user AS author ON author.id = au.user_id
+      LEFT JOIN followeruniverse AS fu ON universe.id = fu.universe_id
+      INNER JOIN user AS owner ON universe.author_id = owner.id
       ${conditionString}
       GROUP BY universe.id;`;
     const data = await executeQuery(queryString, conditions && conditions.values);

--- a/api/routes.js
+++ b/api/routes.js
@@ -24,7 +24,8 @@ module.exports = function(app) {
           res.status(status);
           if (data !== undefined) res.json(data);
         } else {
-          res.status(405);
+          if (path === '/api/*') return res.sendStatus(404);
+          else res.status(405);
         }
         next();
       })
@@ -93,9 +94,9 @@ module.exports = function(app) {
             }),
           ])
         ]),
-        new APIRoute('/follow', {
-          PUT: (req) => api.universe.putUserFollowing(req.session.user, req.params.universeShortName, req.body.isFollowing),
-        }),
+        // new APIRoute('/follow', {
+        //   PUT: (req) => api.universe.putUserFollowing(req.session.user, req.params.universeShortName, req.body.isFollowing),
+        // }),
       ])
     ]),
     new APIRoute('/exists', { POST: async (req) => {
@@ -121,6 +122,7 @@ module.exports = function(app) {
         return [500];
       }
     }}),
+    new APIRoute('/*'),
   ]);
 
   apiRoutes.setup(ADDR_PREFIX);

--- a/api/routes.js
+++ b/api/routes.js
@@ -92,7 +92,10 @@ module.exports = function(app) {
               PUT: (req) => api.item.snoozeUntil(req.session.user, req.params.universeShortName, req.params.itemShortName),
             }),
           ])
-        ])
+        ]),
+        new APIRoute('/follow', {
+          PUT: (req) => api.universe.putUserFollowing(req.session.user, req.params.universeShortName, req.body.isFollowing),
+        }),
       ])
     ]),
     new APIRoute('/exists', { POST: async (req) => {

--- a/api/routes.js
+++ b/api/routes.js
@@ -20,7 +20,6 @@ module.exports = function(app) {
       app.all(path, async (req, res, next) => {
         req.isApiRequest = true;
         const method = req.method.toUpperCase();
-        console.log(path, method)
         if (method in this.methodFuncs) {
           const [status, data] = await this.methodFuncs[method](req);
           res.status(status);

--- a/api/routes.js
+++ b/api/routes.js
@@ -18,14 +18,15 @@ module.exports = function(app) {
       });
       // app.all(path, Auth.verifySession, async (req, res) => {
       app.all(path, async (req, res, next) => {
+        req.isApiRequest = true;
         const method = req.method.toUpperCase();
+        console.log(path, method)
         if (method in this.methodFuncs) {
           const [status, data] = await this.methodFuncs[method](req);
           res.status(status);
           if (data !== undefined) res.json(data);
         } else {
-          if (path === '/api/*') return res.sendStatus(404);
-          else res.status(405);
+          res.status(405);
         }
         next();
       })
@@ -94,9 +95,9 @@ module.exports = function(app) {
             }),
           ])
         ]),
-        // new APIRoute('/follow', {
-        //   PUT: (req) => api.universe.putUserFollowing(req.session.user, req.params.universeShortName, req.body.isFollowing),
-        // }),
+        new APIRoute('/follow', {
+          PUT: (req) => api.universe.putUserFollowing(req.session.user, req.params.universeShortName, req.body.isFollowing),
+        }),
       ])
     ]),
     new APIRoute('/exists', { POST: async (req) => {

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -113,6 +113,14 @@ CREATE TABLE authoruniverse (
   PRIMARY KEY (id)
 );
 
+CREATE TABLE followeruniverse (
+  universe_id INT NOT NULL,
+  user_id INT NOT NULL,
+  is_following BOOLEAN NOT NULL,
+  FOREIGN KEY (universe_id) REFERENCES universe (id),
+  FOREIGN KEY (user_id) REFERENCES user (id)
+);
+
 CREATE TABLE tag (
   item_id INT NOT NULL,
   tag VARCHAR(32),

--- a/index.js
+++ b/index.js
@@ -132,7 +132,8 @@ app.post(`${ADDR_PREFIX}/signup`, async (req, res, next) => {
 app.use((req, res, next) => {
   if (!res.headersSent) {
     res.status(404);
-    res.send(render(req, 'error', { code: 404 }));
+    if (req.isApiRequest) res.json({ error: 'Not Found.', code: 404 });
+    else res.send(render(req, 'error', { code: 404 }));
   }
   next();
 });

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -343,8 +343,25 @@ header {
   margin-top: 0.5rem;
 }
 
+table {
+  border-collapse: collapse;
+  border-radius: 0.25rem;
+  overflow: hidden;
+}
+table thead {
+  background-color: #f3f3f3;
+}
+table th {
+  padding: 0.25rem 0.5rem;
+}
+table tr:nth-child(even) {
+  background-color: #e9e9e9;
+}
 table td {
   padding: 0.0625rem 0.375rem;
+}
+table td:not(:last-child), table th:not(:last-child) {
+  border-right: 1px solid silver;
 }
 
 .nowrap {
@@ -764,4 +781,8 @@ h4, h5 {
 }
 .pa-1 {
   padding: 0.25rem;
+}
+
+.w-100 {
+  width: 100%;
 }

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -559,6 +559,7 @@ h4, h5 {
   position: relative;
   text-decoration: none;
   border: none;
+  cursor: pointer;
 }
 .link.link-animated {
   color: #069;
@@ -619,6 +620,11 @@ h4, h5 {
 }
 .link-animated.link-selected:after {
   background: #636363 !important;
+}
+.link.disabled {
+  pointer-events: none;
+  cursor: default;
+  color: #666;
 }
 
 /* Basic styling for the select dropdown */

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -690,6 +690,9 @@ h4, h5 {
 .align-stretch {
   align-items: stretch;
 }
+.align-baseline {
+  align-items: baseline;
+}
 .align-end {
   align-items: end;
 }

--- a/templates/components/universeList.pug
+++ b/templates/components/universeList.pug
@@ -13,10 +13,35 @@
           .d-flex.gap-2.flex-wrap
             span
               b #{T('Created')}: 
-              | #{formatDate(universe.created_at)}
+              | #{formatDate(universe.created_at, true)}
             | — 
             span 
               b #{T('Updated')}: 
-              | #{formatDate(universe.updated_at)}
+              | #{formatDate(universe.updated_at, true)}
             | —
             span #{universe.public ? 'Public' : 'Private'}
+            | —
+            a.follow-btn.link.link-animated( data-following=universe.followers[contextUser.id] data-universe-short=universe.shortname )
+              | #{universe.followers[contextUser.id] ? 'Unfollow' : 'Follow'}
+  
+  script.
+    document.querySelectorAll('.follow-btn').forEach((followBtn) => {
+      followBtn.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        const { following, universeShort } = followBtn.dataset;
+        let isFollowing = following !== 'true';
+        followBtn.classList.add('disabled');
+        followBtn.classList.remove('link-broken');
+        try {
+          await putJSON(`/api/universes/${universeShort}/follow`, { isFollowing });
+        } catch (err) {
+          console.error(err);
+          followBtn.classList.add('link-broken');
+          isFollowing = !isFollowing;
+        } finally {
+          followBtn.innerText = isFollowing ? 'Unfollow' : 'Follow';
+          followBtn.dataset.following = isFollowing ? 'true' : 'false';
+          followBtn.classList.remove('disabled');
+        }
+      });
+    });

--- a/templates/helpers.pug
+++ b/templates/helpers.pug
@@ -7,7 +7,7 @@
     }
     return prefixedItems;
   };
-  const formatDate = (date) => {
+  const formatDate = (date, intervalOnly=false, short=false) => {
     if (!date) return;
     const now = new Date();
     const secondsAgo = (now - date) / 1000;
@@ -18,6 +18,23 @@
     if (hoursAgo < 24) return `${Math.round(hoursAgo)} hour${Math.round(hoursAgo) === 1 ? '' : 's'} ago`;
     const daysAgo = hoursAgo / 24;
     if (daysAgo < 30) return `${Math.round(daysAgo)} day${Math.round(daysAgo) === 1 ? '' : 's'} ago`;
+    if (intervalOnly) {
+      const weeksAgo = daysAgo / 7;
+      if (Math.round(weeksAgo) < 8) return `${Math.round(weeksAgo)} week${Math.round(weeksAgo) === 1 ? '' : 's'} ago`;
+      const monthDiff = now.getMonth() - date.getMonth();
+      const yearDiff = now.getFullYear() - date.getFullYear();
+      if (yearDiff === 0) {
+        return `${monthDiff} months ago`;
+      } else if (yearDiff === 1) {
+        if (monthDiff < 0) return `${monthDiff + 12} months ago`;
+        else return 'last year';
+      } else {
+        const yearsAgo = yearDiff - (monthDiff < 0 ? 1 : 0);
+        if (yearDiff === 1) return 'last year';
+        else return `${yearDiff} years ago`;
+      }
+    }
 
-    return `on ${date.toDateString()} at ${date.toLocaleTimeString()}`;
+    if (short) return `${date.toDateString()} ${date.toLocaleTimeString()}`;
+    else return `on ${date.toDateString()} at ${date.toLocaleTimeString()}`;
   };

--- a/templates/home.pug
+++ b/templates/home.pug
@@ -53,19 +53,23 @@ block content
             each item in recentlyUpdated
               tr
                 td
-                  a.big-text.link.link-animated( href=`${ADDR_PREFIX}/items/${item.shortname}` ) #{item.title}
+                  a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
                   if !item.last_updated_by
                     small( style='font-size: x-small;' )  (New)
                 td
-                  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
+                  small
+                    a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
                 td
-                  a.link.link-animated( href=`${ADDR_PREFIX}/users/${item.last_updated_by}` ) #{item.last_updated_by || item.author}
-                td #{formatDate(item.updated_at)}
+                  small
+                    a.link.link-animated( href=`${ADDR_PREFIX}/users/${item.last_updated_by}` ) #{item.last_updated_by || item.author}
+                td
+                  small #{formatDate(item.updated_at, true)}
         h2 May Need Review
         table.w-100
           thead
             th Name
             th Universe
+            th Updated
           tbody
             each item in oldestUpdated
               tr
@@ -75,7 +79,10 @@ block content
                       small Snooze
                     a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
                 td
-                  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
+                  small
+                    a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
+                td
+                  small #{formatDate(item.updated_at, true)}
       .grow-1.d-flex.flex-col.gap-1
         .sheet
           h2 My Universes

--- a/templates/home.pug
+++ b/templates/home.pug
@@ -43,36 +43,40 @@ block content
     .d-flex.gap-1.flex-wrap.align-start
       .grow-3.sheet
         h2 Recent Updates by Others
-        ul
-          each item in recentlyUpdated
-            li
-              .d-flex.align-center.gap-2
-                span
-                  //- small
-                  //-   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
-                  //- | /
-                  a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
-                small (
-                  if item.last_updated_by
-                    | Updated by 
-                    a.link.link-animated( href=`${ADDR_PREFIX}/users/${item.last_updated_by}` ) #{item.last_updated_by}
-                  else
-                    | Created by 
-                    a.link.link-animated( href=`${ADDR_PREFIX}/users/${item.author}` ) #{item.author}
-                  |  in 
+        table
+          thead
+            th Name
+            th Universe
+            th Last updated by
+            th Updated
+          tbody
+            each item in recentlyUpdated
+              tr
+                td
+                  a.big-text.link.link-animated( href=`${ADDR_PREFIX}/items/${item.shortname}` ) #{item.title}
+                  if !item.last_updated_by
+                    small( style='font-size: x-small;' )  (New)
+                td
                   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
-                  |  #{formatDate(new Date(item.updated_at))})
+                td
+                  a.link.link-animated( href=`${ADDR_PREFIX}/users/${item.last_updated_by}` ) #{item.last_updated_by || item.author}
+                td #{formatDate(item.updated_at)}
         h2 May Need Review
-        ul
-          each item in oldestUpdated
-            li
-              .d-flex.gap-1.align-baseline.flex-wrap
-                button.pa-1( onclick=`snooze('${item.universe_short}', '${item.shortname}')` data-item=item.shortname )
-                  small Snooze
-                a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
-                small (
+        table
+          thead
+            th
+            th Name
+            th Universe
+          tbody
+            each item in oldestUpdated
+              tr
+                td
+                  button.pa-1( onclick=`snooze('${item.universe_short}', '${item.shortname}')` data-item=item.shortname )
+                    small Snooze
+                td
+                  a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
+                td
                   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
-                  | )
       .grow-1.d-flex.flex-col.gap-1
         .sheet
           h2 My Universes

--- a/templates/home.pug
+++ b/templates/home.pug
@@ -47,7 +47,11 @@ block content
           each item in recentlyUpdated
             li
               .d-flex.align-center.gap-2
-                a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
+                span
+                  //- small
+                  //-   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
+                  //- | /
+                  a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
                 small (
                   if item.last_updated_by
                     | Updated by 
@@ -55,18 +59,30 @@ block content
                   else
                     | Created by 
                     a.link.link-animated( href=`${ADDR_PREFIX}/users/${item.author}` ) #{item.author}
+                  |  in 
+                  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
                   |  #{formatDate(new Date(item.updated_at))})
         h2 May Need Review
         ul
           each item in oldestUpdated
-            li.big-text
-              .d-flex.gap-1
+            li
+              .d-flex.gap-1.align-baseline.flex-wrap
                 button.pa-1( onclick=`snooze('${item.universe_short}', '${item.shortname}')` data-item=item.shortname )
                   small Snooze
-                a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
-      .grow-1.sheet
-        h2 My Universes
-        ul
-          each universe in universes
-            li.big-text
-              a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
+                a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
+                small (
+                  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
+                  | )
+      .grow-1.d-flex.flex-col.gap-1
+        .sheet
+          h2 My Universes
+          ul
+            each universe in universes
+              li.big-text
+                a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
+        .sheet
+          h2 Universes I Follow
+          ul
+            each universe in followedUniverses
+              li.big-text
+                a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}

--- a/templates/home.pug
+++ b/templates/home.pug
@@ -8,7 +8,7 @@ block content
     function snooze(universe, item) {
       if (reloading) return;
       fetch(`/api/universes/${universe}/items/${item}/snooze`, { method: 'PUT' });
-      document.querySelector(`[data-item=${item}]`).parentNode.parentNode.remove();
+      document.querySelector(`[data-item=${item}]`).parentNode.parentNode.parentNode.remove();
       if (snoozeTimeout) clearTimeout(snoozeTimeout);
       snoozeTimeout = setTimeout(() => {
         reloading = true;

--- a/templates/home.pug
+++ b/templates/home.pug
@@ -43,7 +43,7 @@ block content
     .d-flex.gap-1.flex-wrap.align-start
       .grow-3.sheet
         h2 Recent Updates by Others
-        table
+        table.w-100
           thead
             th Name
             th Universe
@@ -62,19 +62,18 @@ block content
                   a.link.link-animated( href=`${ADDR_PREFIX}/users/${item.last_updated_by}` ) #{item.last_updated_by || item.author}
                 td #{formatDate(item.updated_at)}
         h2 May Need Review
-        table
+        table.w-100
           thead
-            th
             th Name
             th Universe
           tbody
             each item in oldestUpdated
               tr
                 td
-                  button.pa-1( onclick=`snooze('${item.universe_short}', '${item.shortname}')` data-item=item.shortname )
-                    small Snooze
-                td
-                  a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
+                  .d-flex.gap-1
+                    button.pa-1( onclick=`snooze('${item.universe_short}', '${item.shortname}')` data-item=item.shortname )
+                      small Snooze
+                    a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
                 td
                   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
       .grow-1.d-flex.flex-col.gap-1

--- a/templates/home.pug
+++ b/templates/home.pug
@@ -43,27 +43,32 @@ block content
     .d-flex.gap-1.flex-wrap.align-start
       .grow-3.sheet
         h2 Recent Updates by Others
-        table.w-100
-          thead
-            th Name
-            th Universe
-            th Last updated by
-            th Updated
-          tbody
-            each item in recentlyUpdated
-              tr
-                td
-                  a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
-                  if !item.last_updated_by
-                    small( style='font-size: x-small;' )  (New)
-                td
-                  small
-                    a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
-                td
-                  small
-                    a.link.link-animated( href=`${ADDR_PREFIX}/users/${item.last_updated_by}` ) #{item.last_updated_by || item.author}
-                td
-                  small #{formatDate(item.updated_at, true)}
+        if followedUniverses.length > 0
+          table.w-100
+            thead
+              th Name
+              th Universe
+              th Last updated by
+              th Updated
+            tbody
+              each item in recentlyUpdated
+                tr
+                  td
+                    a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
+                    if !item.last_updated_by
+                      small( style='font-size: x-small;' )  (New)
+                  td
+                    small
+                      a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
+                  td
+                    small
+                      a.link.link-animated( href=`${ADDR_PREFIX}/users/${item.last_updated_by}` ) #{item.last_updated_by || item.author}
+                  td
+                    small #{formatDate(item.updated_at, true)}
+        else
+          p No updates here — try following some 
+            a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) universes
+            |  first!
         h2 May Need Review
         table.w-100
           thead

--- a/templates/index.js
+++ b/templates/index.js
@@ -38,7 +38,7 @@ function contextData(req) {
   const contextUser = user ? {
     id: user.id,
     username: user.username,
-    gravatarLink: `http://www.gravatar.com/avatar/${md5(user.email)}.jpg`,
+    gravatarLink: `https://www.gravatar.com/avatar/${md5(user.email)}.jpg`,
   } : null;
 
   const lang = 'en';

--- a/templates/list/universes.pug
+++ b/templates/list/universes.pug
@@ -9,6 +9,7 @@ block breadcrumbs
 block content
   script
     include /static/scripts/cardUtils.js
+    include /static/scripts/fetchUtils.js
   
   h1.center Universes
   a.link.link-animated( href=`${ADDR_PREFIX}/universes/create` ) Create New

--- a/templates/view/universe.pug
+++ b/templates/view/universe.pug
@@ -18,24 +18,53 @@ block breadcrumbs
   |  / 
   span #{universe.title}
 
-block content
+block scripts
   script
     include /static/scripts/tabs.js
     include /static/scripts/cardUtils.js
+    include /static/scripts/fetchUtils.js
 
+block content
   h1.center #{universe.title}
   p.center
     small Created by 
       a.link.link-animated( href=`${ADDR_PREFIX}/users/${universe.owner}` ) #{universe.owner}
       |  #{formatDate(new Date(universe.created_at))}
       |  - Last updated #{formatDate(new Date(universe.updated_at))}
-      if contextUser && (universe.author_permissions[contextUser.id] >= perms.ADMIN)
+      if contextUser
+        script!= `isFollowing = ${universe.followers[contextUser.id]};`
+        script!= `universeShort = '${universe.shortname}';`
         |  - 
-        a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/edit` ) Edit
-        |  - 
-        a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/permissions` ) Set Permissions
-        |  - 
-        a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/delete` ) Delete
+        a#follow-btn.link.link-animated
+          if universe.followers[contextUser.id]
+            | Unfollow
+          else
+            | Follow
+          script.
+            let isFollowing = false;
+            const followBtn = document.getElementById('follow-btn');
+            followBtn.addEventListener('click', async () => {
+              isFollowing = !isFollowing;
+              followBtn.classList.add('disabled');
+              followBtn.classList.remove('link-broken');
+              try {
+                await putJSON(`/api/universes/${universeShort}/follow`, { isFollowing: isFollowing });
+              } catch (err) {
+                console.error(err);
+                isFollowing = !isFollowing;
+                followBtn.classList.add('link-broken');
+              } finally {
+                followBtn.innerText = isFollowing ? 'Unfollow' : 'Follow';
+                followBtn.classList.remove('disabled');
+              }
+            });
+        if universe.author_permissions[contextUser.id] >= perms.ADMIN
+          |  - 
+          a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/edit` ) Edit
+          |  - 
+          a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/permissions` ) Set Permissions
+          |  - 
+          a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/delete` ) Delete
 
   hr
 

--- a/views.js
+++ b/views.js
@@ -50,8 +50,8 @@ module.exports = function(app) {
       res.status(code1);
       if (!universes) return;
       const [code2, recentlyUpdated] = await api.item.getMany(user, {
-        strings: ['lub.id <> ? OR item.last_updated_by IS NULL', 'item.author_id <> ?'],
-        values: [user.id, user.id],
+        strings: ['lub.id <> ? OR item.last_updated_by IS NULL'],
+        values: [user.id],
       }, perms.READ, true, {
         sort: 'updated_at',
         sortDesc: true,

--- a/views.js
+++ b/views.js
@@ -99,7 +99,7 @@ module.exports = function(app) {
     if (!contacts) return;
     const gravatarContacts = contacts.map(user => ({
       ...user,
-      gravatarLink: `http://www.gravatar.com/avatar/${md5(user.email)}.jpg`,
+      gravatarLink: `https://www.gravatar.com/avatar/${md5(user.email)}.jpg`,
     }));
     res.prepareRender('contactList', {
       contacts: gravatarContacts.filter(contact => contact.accepted),
@@ -124,7 +124,7 @@ module.exports = function(app) {
     }
     res.prepareRender('user', { 
       user,
-      gravatarLink: `http://www.gravatar.com/avatar/${md5(user.email)}.jpg`,
+      gravatarLink: `https://www.gravatar.com/avatar/${md5(user.email)}.jpg`,
       universes,
     });
   });
@@ -162,7 +162,7 @@ module.exports = function(app) {
     authors.forEach(author => {
       authorMap[author.id] = {
         ...author,
-        gravatarLink: `http://www.gravatar.com/avatar/${md5(author.email)}.jpg`,
+        gravatarLink: `https://www.gravatar.com/avatar/${md5(author.email)}.jpg`,
       };
     });
     res.prepareRender('universe', { universe, authors: authorMap });

--- a/views.js
+++ b/views.js
@@ -49,31 +49,36 @@ module.exports = function(app) {
       const [code1, universes] = await api.universe.getMany(user, null, perms.WRITE);
       res.status(code1);
       if (!universes) return;
-      const [code2, recentlyUpdated] = await api.item.getMany(user, {
-        strings: ['lub.id <> ? OR item.last_updated_by IS NULL'],
-        values: [user.id],
-      }, perms.READ, true, {
+      const [code2, followedUniverses] = await api.universe.getMany(user, {
+        strings: ['fu.user_id = ?', 'fu.is_following = ?'],
+        values: [user.id, true],
+      }, perms.READ);
+      res.status(code2);
+      if (!followedUniverses) return;
+      const followedUniverseIds = `(${followedUniverses.map(universe => universe.id).join(',')})`;
+      const [code3, recentlyUpdated] = await api.item.getMany(user, null, perms.READ, true, {
         sort: 'updated_at',
         sortDesc: true,
         limit: 8,
         select: [['lub.username', 'last_updated_by']],
         join: [['LEFT', ['user', 'lub'], new Cond('lub.id = item.last_updated_by')]],
-        where: new Cond('au_filter.user_id = ?', user.id),
+        where: new Cond(`item.universe_id IN ${followedUniverseIds}`)
+          .and(new Cond('lub.id <> ?', user.id).or('item.last_updated_by IS NULL')),
       });
-      res.status(code2);
-      const [code3, oldestUpdated] = await api.item.getMany(user, null, perms.WRITE, true, {
+      res.status(code3);
+      const [code4, oldestUpdated] = await api.item.getMany(user, null, perms.WRITE, true, {
         sort: 'updated_at',
         sortDesc: false,
         limit: 16,
         join: [['LEFT', 'snooze', new Cond('snooze.item_id = item.id').and('snooze.snoozed_by = ?', user.id)]],
         where: new Cond('snooze.snoozed_until < NOW()').or('snooze.snoozed_until IS NULL').and('item.updated_at < DATE_SUB(NOW(), INTERVAL 2 DAY)'),
       });
-      res.status(code3);
+      res.status(code4);
       if (!oldestUpdated) return;
       // if (universes.length === 1) {
       //   res.redirect(`${ADDR_PREFIX}/universes/${universes[0].shortname}`);
       // }
-      return res.prepareRender('home', { universes, recentlyUpdated, oldestUpdated });
+      return res.prepareRender('home', { universes, followedUniverses, recentlyUpdated, oldestUpdated });
     }
     res.prepareRender('home', { universes: [] })
   });

--- a/views.js
+++ b/views.js
@@ -56,7 +56,7 @@ module.exports = function(app) {
       res.status(code2);
       if (!followedUniverses) return;
       const followedUniverseIds = `(${followedUniverses.map(universe => universe.id).join(',')})`;
-      const [code3, recentlyUpdated] = await api.item.getMany(user, null, perms.READ, true, {
+      const [code3, recentlyUpdated] = followedUniverses.length > 0 ? await api.item.getMany(user, null, perms.READ, true, {
         sort: 'updated_at',
         sortDesc: true,
         limit: 8,
@@ -64,7 +64,7 @@ module.exports = function(app) {
         join: [['LEFT', ['user', 'lub'], new Cond('lub.id = item.last_updated_by')]],
         where: new Cond(`item.universe_id IN ${followedUniverseIds}`)
           .and(new Cond('lub.id <> ?', user.id).or('item.last_updated_by IS NULL')),
-      });
+      }) : [200, []];
       res.status(code3);
       const [code4, oldestUpdated] = await api.item.getMany(user, null, perms.WRITE, true, {
         sort: 'updated_at',


### PR DESCRIPTION
fixes #4, closes #45

- You can specifically "follow" any universe you have read access to. Only items from universes you follow show up in your "Recent Updates by Others" list.
- Use tables on home page instead of bullet lists.
- Failed API routes now return a simple json error and code instead of HTML.

![image](https://github.com/user-attachments/assets/86aaf770-4361-4576-8532-9761f5210fac)
![image](https://github.com/user-attachments/assets/3cbc66ab-d855-450f-a2d3-c4f57dbd55b5)
