### PR TITLE
Discussion & Comments

### DIFF
--- a/api/models/discussion.js
+++ b/api/models/discussion.js
@@ -1,0 +1,50 @@
+const { executeQuery, parseData, perms } = require('../utils');
+const universeapi = require('./universe');
+
+async function getThread(user, options, permissionLevel=perms.READ) {
+  try {
+    const parsedOptions = parseData(options);
+    const readOnlyQueryString = permissionLevel > perms.READ ? '' : `universe.public = 1`;
+    const usrQueryString = user ? `(au_filter.user_id = ${user.id} AND au_filter.permission_level >= ${permissionLevel})` : '';
+    const permsQueryString = `${readOnlyQueryString}${(readOnlyQueryString && usrQueryString) ? ' OR ' : ''}${usrQueryString}`;
+    const conditionString = options ? `WHERE ${parsedOptions.strings.join(' AND ')}` : '';
+    const queryString = `
+      SELECT discussion.*
+      FROM universethread
+      INNER JOIN discussion ON discussion.id = universethread.thread_id
+      INNER JOIN universe ON universe.id = universethread.universe_id
+      INNER JOIN authoruniverse as au_filter
+        ON universe.id = au_filter.universe_id AND (
+          ${permsQueryString}
+        )
+      LEFT JOIN authoruniverse as au ON universe.id = au.universe_id
+      ${conditionString}
+      GROUP BY discussion.id;`;
+    const data = await executeQuery(queryString, options && parsedOptions.values);
+    return [200, data];
+  } catch (err) {
+    console.error(err);
+    return [500];
+  }
+}
+
+async function postUniverseThread(user, universeShortname, { title }) {
+  const [code, universe] = await universeapi.getOne(user, { shortname: universeShortname }, perms.COMMENT);
+  if (!universe) return [code];
+  if (!universe.discussion_enabled) return [403];
+
+  try {
+    const queryString1 = `INSERT INTO discussion (title) VALUES (?);`;
+    const data = await executeQuery(queryString1, [ title ?? null ]);
+    const queryString2 = `INSERT INTO universethread (universe_id, thread_id) VALUES (?, ?)`;
+    return [201, [data, await executeQuery(queryString2, [ universe.id, data.insertId ])]];
+  } catch (err) {
+    console.error(err);
+    return [500];
+  }
+}
+
+module.exports = {
+  getThread,
+  postUniverseThread,
+};

--- a/api/models/discussion.js
+++ b/api/models/discussion.js
@@ -1,7 +1,7 @@
 const { executeQuery, parseData, perms } = require('../utils');
 const universeapi = require('./universe');
 
-async function getThread(user, options, permissionLevel=perms.READ) {
+async function getThreads(user, options, permissionLevel=perms.READ) {
   try {
     const parsedOptions = parseData(options);
     const readOnlyQueryString = permissionLevel > perms.READ ? '' : `universe.public = 1`;
@@ -32,12 +32,29 @@ async function postUniverseThread(user, universeShortname, { title }) {
   const [code, universe] = await universeapi.getOne(user, { shortname: universeShortname }, perms.COMMENT);
   if (!universe) return [code];
   if (!universe.discussion_enabled) return [403];
+  if (!title) return [400, 'Title is required for universe discussion threads.'];
 
   try {
     const queryString1 = `INSERT INTO discussion (title) VALUES (?);`;
     const data = await executeQuery(queryString1, [ title ?? null ]);
     const queryString2 = `INSERT INTO universethread (universe_id, thread_id) VALUES (?, ?)`;
-    return [201, [data, await executeQuery(queryString2, [ universe.id, data.insertId ])]];
+    await executeQuery(queryString2, [ universe.id, data.insertId ])
+    return [201, data];
+  } catch (err) {
+    console.error(err);
+    return [500];
+  }
+}
+
+async function postComment(user, threadId, { body }) {
+  const [code, threads] = await getThreads(user, { 'discussion.id': threadId }, perms.COMMENT);
+  const thread = threads[0];
+  if (!thread) return [code];
+  if (!body) return [400];
+
+  try {
+    const queryString = `INSERT INTO comment (body, author_id, thread_id, created_at) VALUES (?, ?, ?, ?);`;
+    return [201, await executeQuery(queryString, [ body, user.id, thread.id, new Date() ])];
   } catch (err) {
     console.error(err);
     return [500];
@@ -45,6 +62,7 @@ async function postUniverseThread(user, universeShortname, { title }) {
 }
 
 module.exports = {
-  getThread,
+  getThreads,
   postUniverseThread,
+  postComment,
 };

--- a/api/models/universe.js
+++ b/api/models/universe.js
@@ -129,7 +129,7 @@ async function post(user, body) {
 }
 
 async function put(user, shortname, changes) {
-  const { title, public, obj_data } = changes;
+  const { title, public, discussion_enabled, obj_data } = changes;
 
   if (!title) return [400];
   const [code, universe] = await getOne(user, { shortname }, perms.WRITE);
@@ -141,11 +141,12 @@ async function put(user, shortname, changes) {
       SET
         title = ?,
         public = ?,
+        discussion_enabled = ?,
         obj_data = ?,
         updated_at = ?
       WHERE id = ?;
     `;
-    return [200, await executeQuery(queryString, [ title, public, obj_data, new Date(), universe.id ])];
+    return [200, await executeQuery(queryString, [ title, public, discussion_enabled, obj_data, new Date(), universe.id ])];
   } catch (err) {
     logger.error(err);
     return [500];

--- a/api/models/universe.js
+++ b/api/models/universe.js
@@ -88,7 +88,7 @@ function getManyByAuthorName(user, authorName) {
 
 async function post(user, body) {
   try {
-    const { title, shortname, public, discussion_enabled, obj_data } = body;
+    const { title, shortname, public, discussion_enabled, discussion_open, obj_data } = body;
     if (!(title && shortname)) return [400, 'Missing parameters.'];
     const queryString1 = `
       INSERT INTO universe (
@@ -97,6 +97,7 @@ async function post(user, body) {
         author_id,
         public,
         discussion_enabled,
+        discussion_open,
         obj_data,
         created_at,
         updated_at
@@ -108,6 +109,7 @@ async function post(user, body) {
       user.id,
       public,
       discussion_enabled,
+      discussion_open,
       obj_data,
       new Date(),
       new Date(),
@@ -123,7 +125,7 @@ async function post(user, body) {
 }
 
 async function put(user, shortname, changes) {
-  const { title, public, discussion_enabled, obj_data } = changes;
+  const { title, public, discussion_enabled, discussion_open, obj_data } = changes;
 
   if (!title) return [400];
   const [code, universe] = await getOne(user, { shortname }, perms.WRITE);
@@ -136,11 +138,12 @@ async function put(user, shortname, changes) {
         title = ?,
         public = ?,
         discussion_enabled = ?,
+        discussion_open = ?,
         obj_data = ?,
         updated_at = ?
       WHERE id = ?;
     `;
-    return [200, await executeQuery(queryString, [ title, public, discussion_enabled, obj_data, new Date(), universe.id ])];
+    return [200, await executeQuery(queryString, [ title, public, discussion_enabled, discussion_open, obj_data, new Date(), universe.id ])];
   } catch (err) {
     logger.error(err);
     return [500];

--- a/api/models/universe.js
+++ b/api/models/universe.js
@@ -32,10 +32,6 @@ async function getMany(user, conditions, permissionLevel=perms.READ) {
         JSON_OBJECTAGG(author.id, au.permission_level) AS author_permissions,
         owner.username AS owner,
         JSON_REMOVE(JSON_OBJECTAGG(
-          IFNULL(discussion.id, 'null__'),
-          discussion.title
-        ), '$.null__') AS discussion_threads,
-        JSON_REMOVE(JSON_OBJECTAGG(
           IFNULL(fu.user_id, 'null__'),
           fu.is_following
         ), '$.null__') AS followers
@@ -47,8 +43,6 @@ async function getMany(user, conditions, permissionLevel=perms.READ) {
       LEFT JOIN authoruniverse AS au ON universe.id = au.universe_id
       LEFT JOIN user AS author ON author.id = au.user_id
       LEFT JOIN followeruniverse AS fu ON universe.id = fu.universe_id
-      LEFT JOIN universethread as ut ON universe.id = ut.universe_id
-      LEFT JOIN discussion ON discussion.id = ut.thread_id
       INNER JOIN user AS owner ON universe.author_id = owner.id
       ${conditionString}
       GROUP BY universe.id;`;

--- a/api/routes.js
+++ b/api/routes.js
@@ -98,6 +98,10 @@ module.exports = function(app) {
         new APIRoute('/follow', {
           PUT: (req) => api.universe.putUserFollowing(req.session.user, req.params.universeShortName, req.body.isFollowing),
         }),
+        new APIRoute('/discussion', {
+          GET: (req) => api.discussion.getThread(req.session.user, { 'universe.shortname': req.params.universeShortName }),
+          POST: (req) => api.discussion.postThread(req.session.user, req.params.universeShortName, req.body),
+        }, []),
       ])
     ]),
     new APIRoute('/exists', { POST: async (req) => {

--- a/api/routes.js
+++ b/api/routes.js
@@ -99,7 +99,10 @@ module.exports = function(app) {
           PUT: (req) => api.universe.putUserFollowing(req.session.user, req.params.universeShortName, req.body.isFollowing),
         }),
         new APIRoute('/discussion', {
-          GET: (req) => api.discussion.getThread(req.session.user, { 'universe.shortname': req.params.universeShortName }),
+          GET: (req) => frmtData(
+            api.discussion.getThreads(req.session.user, { 'universe.shortname': req.params.universeShortName }),
+            (data) => data[0],
+          ),
           POST: (req) => api.discussion.postThread(req.session.user, req.params.universeShortName, req.body),
         }, []),
       ])

--- a/api/utils.js
+++ b/api/utils.js
@@ -4,8 +4,9 @@ const _ = require('lodash');
 const perms = {
   NONE: 0,
   READ: 1,
-  WRITE: 2,
-  ADMIN: 3,
+  COMMENT: 2,
+  WRITE: 3,
+  ADMIN: 4,
 };
 
 const executeQuery = (query, values) => {

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -35,6 +35,7 @@ CREATE TABLE universe (
   updated_at TIMESTAMP NOT NULL,
   public BOOLEAN NOT NULL,
   discussion_enabled BOOLEAN NOT NULL,
+  discussion_open BOOLEAN NOT NULL,
   obj_data TEXT NOT NULL,
   FOREIGN KEY (author_id) REFERENCES user (id),
   PRIMARY KEY (id)
@@ -42,24 +43,26 @@ CREATE TABLE universe (
 
 CREATE TABLE discussion (
   id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-  title VARCHAR(256)
+  title VARCHAR(256) NOT NULL,
+  universe_id INT NOT NULL,
+  FOREIGN KEY (universe_id) REFERENCES universe (id)
 );
 
 CREATE TABLE comment (
   id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   body VARCHAR(2048) NOT NULL,
   author_id INT NOT NULL,
-  thread_id INT NOT NULL,
+  reply_to INT,
   created_at TIMESTAMP NOT NULL,
   FOREIGN KEY (author_id) REFERENCES user (id),
-  FOREIGN KEY (thread_id) REFERENCES discussion (id)
+  FOREIGN KEY (reply_to) REFERENCES comment (id)
 );
 
-CREATE TABLE universethread (
-  universe_id INT NOT NULL,
+CREATE TABLE threadcomment (
   thread_id INT NOT NULL,
-  FOREIGN KEY (universe_id) REFERENCES universe (id),
-  FOREIGN KEY (thread_id) REFERENCES discussion (id)
+  comment_id INT NOT NULL,
+  FOREIGN KEY (thread_id) REFERENCES discussion (id),
+  FOREIGN KEY (comment_id) REFERENCES comment (id)
 );
 
 CREATE TABLE item (
@@ -82,11 +85,11 @@ CREATE TABLE item (
   PRIMARY KEY (id)
 );
 
-CREATE TABLE itemthread (
+CREATE TABLE itemcomment (
   item_id INT NOT NULL,
-  thread_id INT NOT NULL,
+  comment_id INT NOT NULL,
   FOREIGN KEY (item_id) REFERENCES item (id),
-  FOREIGN KEY (thread_id) REFERENCES discussion (id)
+  FOREIGN KEY (comment_id) REFERENCES comment (id)
 );
 
 CREATE TABLE snooze (

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -34,9 +34,32 @@ CREATE TABLE universe (
   created_at TIMESTAMP NOT NULL,
   updated_at TIMESTAMP NOT NULL,
   public BOOLEAN NOT NULL,
+  discussion_enabled BOOLEAN NOT NULL,
   obj_data TEXT NOT NULL,
   FOREIGN KEY (author_id) REFERENCES user (id),
   PRIMARY KEY (id)
+);
+
+CREATE TABLE discussion (
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(256)
+);
+
+CREATE TABLE comment (
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  body VARCHAR(2048) NOT NULL,
+  author_id INT NOT NULL,
+  thread_id INT NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  FOREIGN KEY (author_id) REFERENCES user (id),
+  FOREIGN KEY (thread_id) REFERENCES discussion (id)
+);
+
+CREATE TABLE universethread (
+  universe_id INT NOT NULL,
+  thread_id INT NOT NULL,
+  FOREIGN KEY (universe_id) REFERENCES universe (id),
+  FOREIGN KEY (thread_id) REFERENCES discussion (id)
 );
 
 CREATE TABLE item (
@@ -57,6 +80,13 @@ CREATE TABLE item (
   FOREIGN KEY (parent_id) REFERENCES item (id),
   FOREIGN KEY (last_updated_by) REFERENCES user (id),
   PRIMARY KEY (id)
+);
+
+CREATE TABLE itemthread (
+  item_id INT NOT NULL,
+  thread_id INT NOT NULL,
+  FOREIGN KEY (item_id) REFERENCES item (id),
+  FOREIGN KEY (thread_id) REFERENCES discussion (id)
 );
 
 CREATE TABLE snooze (

--- a/index.js
+++ b/index.js
@@ -145,6 +145,7 @@ app.use((req, res, next) => {
 // Logger if in Dev Mode
 if (DEV_MODE) {
   app.use('/', (req, res, next) => {
+    // console.log(req.headers['x-subdomain'])
     const endTime = new Date();
     let clientIp = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
     // If the IP is in IPv6-mapped IPv4 format, extract the IPv4 part

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -776,6 +776,13 @@ h4, h5 {
   margin: 0.25rem;
 }
 
+.mr-1 {
+  margin-right: 0.25rem;
+}
+.mr-2 {
+  margin-right: 0.5rem;
+}
+
 .pa-0 {
   padding: 0;
 }

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -391,14 +391,19 @@ button {
   transition: box-shadow 0.1s;
 }
 
-button:hover {
+button:hover:not(:disabled) {
   box-shadow: silver 0 0 0.25rem;
 }
 
-button:active {
+button:active:not(:disabled) {
   background-color: #e2e2e2;
 }
 
+button:disabled {
+  color: #888;
+  border-color: #ddd;
+}
+ 
 .inputGroup {
   display: grid;
   grid-template-columns: 1fr 0.5rem 2fr 3fr;
@@ -424,6 +429,14 @@ button:active {
 .editor {
   display: grid;
   margin: 0.75rem 0;
+  position: relative;
+}
+
+.editor .chars {
+  position: absolute;
+  bottom: 0.125rem;
+  right: 0.25rem;
+  color: silver;
 }
 
 .editor::after {

--- a/static/scripts/itemEditor.js
+++ b/static/scripts/itemEditor.js
@@ -415,7 +415,7 @@ async function resetTabs(toSelect=null) {
   document.querySelector(`#tabs .tabs-buttons`).innerHTML = '';
   document.querySelector(`#tabs .tabs-content`).innerHTML = '';
   let firstTab = null;
-  for (const type of ['lineage', 'location', 'timeline', 'gallery']) {
+  for (const type of ['lineage', 'location', 'timeline', 'gallery', 'comments']) {
     if (type in obj_data) {
       await addTab(type, obj_data[type].title, true);
     }

--- a/templates/components/comments.pug
+++ b/templates/components/comments.pug
@@ -17,9 +17,19 @@ div
   if contextUser && (universe.author_permissions[contextUser.id] >= (universe.discussion_open ? perms.READ : perms.COMMENT))
     form( method='POST' action=commentAction )
       .editor( data-replicated-value='' )
-        textarea( id='body' name='body' oninput="this.parentNode.dataset.replicatedValue = this.value" )
+        textarea.comment-field( id='body' name='body' oninput="t" )
+        span.chars 2000
       div
-        button( type='submit' ) Post Comment
+        button#post( type='submit' ) Post Comment
       if error
         div
           span( style={'font-size': 'small'} ).color-error= error
+
+  script.
+    document.querySelectorAll('textarea.comment-field').forEach(el => {
+      el.oninput = () => {
+        el.parentNode.dataset.replicatedValue = el.value;
+        el.parentNode.querySelector('.chars').innerText = 2000 - el.value.length;
+        el.form.post.disabled = el.value.length > 2000;
+      };
+    });

--- a/templates/components/comments.pug
+++ b/templates/components/comments.pug
@@ -1,0 +1,25 @@
+div
+  .d-flex.flex-col.gap-4
+    each comment in comments
+      .sheet.d-flex.gap-4.align-start
+        img.userIcon( alt=commenters[comment.author_id].username, src=commenters[comment.author_id].gravatarLink )
+        .d-flex.flex-col.grow-1
+          div
+            a.link.link-animated.mr-2( href=`/users/${commenters[comment.author_id].username}` ) 
+              b #{commenters[comment.author_id].username}
+            small #{formatDate(comment.created_at)}
+          .comment( data-val=comment.body )
+
+  br
+  hr
+  br
+
+  if contextUser && (universe.author_permissions[contextUser.id] >= (universe.discussion_open ? perms.READ : perms.COMMENT))
+    form( method='POST' action=commentAction )
+      .editor( data-replicated-value='' )
+        textarea( id='body' name='body' oninput="this.parentNode.dataset.replicatedValue = this.value" )
+      div
+        button( type='submit' ) Post Comment
+      if error
+        div
+          span( style={'font-size': 'small'} ).color-error= error

--- a/templates/create/universe.pug
+++ b/templates/create/universe.pug
@@ -27,6 +27,11 @@ block content
       select( id='visibility' name='visibility' )
         option( value='public' selected=(visibility === 'public') ) Public
         option( value='private' selected=(visibility === 'private') ) Private
+    div.inputGroup
+      label( for='discussion_enabled' ) Discussion: 
+      select( id='discussion_enabled' name='discussion_enabled' )
+        option( value='enabled' selected=(discussion_enabled === 'enabled') ) Enabled
+        option( value='disabled' selected=(discussion_enabled === 'disabled') ) Disabled
     div
       input( type='hidden' id='obj_data' name='obj_data' value='{}' )
       button( type='submit' ) Create Universe

--- a/templates/create/universe.pug
+++ b/templates/create/universe.pug
@@ -32,6 +32,11 @@ block content
       select( id='discussion_enabled' name='discussion_enabled' )
         option( value='enabled' selected=(discussion_enabled === 'enabled') ) Enabled
         option( value='disabled' selected=(discussion_enabled === 'disabled') ) Disabled
+    div.inputGroup
+      label( for='discussion_open' ) Who can comment: 
+      select( id='discussion_open' name='discussion_open' )
+        option( value='enabled' selected=(universe.discussion_open) ) Anyone
+        option( value='disabled' selected=(!universe.discussion_open) ) Only with COMMENT permission level
     div
       input( type='hidden' id='obj_data' name='obj_data' value='{}' )
       button( type='submit' ) Create Universe

--- a/templates/create/universeThread.pug
+++ b/templates/create/universeThread.pug
@@ -1,0 +1,27 @@
+extends ../layout.pug
+
+block breadcrumbs
+  a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
+  |  / 
+  a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
+  |  / 
+  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
+  |  / 
+  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/discuss` ) #{T('Discuss')}
+  |  / 
+  span #{T('New')}
+
+block content
+  h2 New Discussion Thread
+  form( method='POST' )
+    div.inputGroup
+      label( for='title' ) Subject: 
+      input( id='title' type='text' name='title' value=`${title || ''}` )
+    div.inputGroup
+      label( for='comment' ) Message: 
+      textarea( id='comment' name='comment' value=`${comment || ''}` )
+    div
+      button( type='submit' ) Create Thread
+    if error
+      div
+        span( style={'font-size': 'small'} ).color-error= error

--- a/templates/create/universeThread.pug
+++ b/templates/create/universeThread.pug
@@ -7,7 +7,7 @@ block breadcrumbs
   |  / 
   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
   |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/discuss` ) #{T('Discuss')}
+  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}?tab=discuss` ) #{T('Discuss')}
   |  / 
   span #{T('New')}
 

--- a/templates/edit/item.pug
+++ b/templates/edit/item.pug
@@ -45,7 +45,7 @@ block content
         button( type='button' onclick=`addTabByType()` )= T('New Tab')
         select( id='new_tab_type' onchange='handleTypeChange()' )
           option( hidden disabled selected value ) #{T('Tab Type')}...
-          each type in ['lineage', 'location', 'timeline', 'gallery']
+          each type in ['lineage', 'location', 'timeline', 'gallery', 'comments']
             option( value=type )= capitalize(T(type))
           option( value='custom' )= T('Custom Data')
         input( id='new_tab' type='text' placeholder='Tab Name' ).hidden

--- a/templates/edit/universe.pug
+++ b/templates/edit/universe.pug
@@ -31,6 +31,12 @@ block content
         option( value='enabled' selected=(universe.discussion_enabled) ) Enabled
         option( value='disabled' selected=(!universe.discussion_enabled) ) Disabled
 
+    div.inputGroup
+      label( for='discussion_open' ) Who can comment: 
+      select( id='discussion_open' name='discussion_open' )
+        option( value='enabled' selected=(universe.discussion_open) ) Anyone
+        option( value='disabled' selected=(!universe.discussion_open) ) Only with COMMENT permission level
+
     h3 Item Types
     #cats
 

--- a/templates/edit/universe.pug
+++ b/templates/edit/universe.pug
@@ -1,5 +1,10 @@
 extends ../layout.pug
 
+block append save
+  li#save-btn.navbarBtn
+    script.
+    a.navbarBtnLink.navbarText( onclick='document.forms.edit.submit()' ) Save Changes
+
 block content
   script
     include /static/scripts/domUtils.js
@@ -8,7 +13,7 @@ block content
     include /static/scripts/universes.js
 
   h2 Edit #{universe.title}
-  form( method='POST' )
+  form#edit( method='POST' )
 
     div.inputGroup
       label( for='title' ) Title: 
@@ -20,12 +25,17 @@ block content
         option( value='public' selected=(universe.public) ) Public
         option( value='private' selected=(!universe.public) ) Private
 
+    div.inputGroup
+      label( for='discussion_enabled' ) Discussion: 
+      select( id='discussion_enabled' name='discussion_enabled' )
+        option( value='enabled' selected=(universe.discussion_enabled) ) Enabled
+        option( value='disabled' selected=(!universe.discussion_enabled) ) Disabled
+
     h3 Item Types
     #cats
 
     div
       input( id='obj_data' type='hidden' name='obj_data' value='{}' )
-      button( type='submit' ) Save Changes
 
     if error
       div

--- a/templates/index.js
+++ b/templates/index.js
@@ -27,6 +27,7 @@ const locale = {
     missing_cat: 'Missing Category',
     [`perms_${perms.NONE}`]: 'None',
     [`perms_${perms.READ}`]: 'Read',
+    [`perms_${perms.COMMENT}`]: 'Comment',
     [`perms_${perms.WRITE}`]: 'Write',
     [`perms_${perms.ADMIN}`]: 'Admin',
   }

--- a/templates/index.js
+++ b/templates/index.js
@@ -86,6 +86,7 @@ const templates = {
   universeList: compile('templates/list/universes.pug'),
   createUniverse: compile('templates/create/universe.pug'),
   editUniversePerms: compile('templates/edit/universePerms.pug'),
+  universeThread: compile('templates/view/universeThread.pug'),
   createUniverseThread: compile('templates/create/universeThread.pug'),
 
   item: compile('templates/view/item.pug'),

--- a/templates/index.js
+++ b/templates/index.js
@@ -86,6 +86,7 @@ const templates = {
   universeList: compile('templates/list/universes.pug'),
   createUniverse: compile('templates/create/universe.pug'),
   editUniversePerms: compile('templates/edit/universePerms.pug'),
+  createUniverseThread: compile('templates/create/universeThread.pug'),
 
   item: compile('templates/view/item.pug'),
   editItem: compile('templates/edit/item.pug'),

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -67,7 +67,7 @@ block content
     if 'lineage' in item.obj_data && 'title' in item.obj_data.lineage
       li.navbarBtn( data-tab='lineage' )
           h3.navbarBtnLink.navbarText( onclick=`showTab('lineage')` ) #{item.obj_data.lineage.title}
-    if 'comments' in item.obj_data
+    if 'comments' in item.obj_data && 'title' in item.obj_data.comments
       li.navbarBtn( data-tab='comments' )
           h3.navbarBtnLink.navbarText( onclick=`showTab('comments')` ) #{capitalize(T('comments'))}
 
@@ -121,7 +121,7 @@ block content
             a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/items/${shortname}` )
               | #{item.child_titles[shortname]}
         
-    if 'comments' in item.obj_data
+    if 'comments' in item.obj_data && 'title' in item.obj_data.comments
       .hidden( data-tab='comments' )
         .d-flex.flex-col.gap-4
           each comment in comments
@@ -137,7 +137,7 @@ block content
         hr
         br
 
-        if contextUser && (universe.author_permissions[contextUser.id] >= perms.COMMENT)
+        if contextUser && (universe.author_permissions[contextUser.id] >= (universe.discussion_open ? perms.READ : perms.COMMENT))
           form( method='POST' action=`/universes/${universe.shortname}/items/${item.shortname}/comment` )
             div
               textarea( id='body' name='body' value=`${comment || ''}` )

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -123,29 +123,7 @@ block content
         
     if 'comments' in item.obj_data && 'title' in item.obj_data.comments
       .hidden( data-tab='comments' )
-        .d-flex.flex-col.gap-4
-          each comment in comments
-            .sheet.d-flex.gap-4.align-start
-              img.userIcon( alt=commenters[comment.author_id].username, src=commenters[comment.author_id].gravatarLink )
-              .d-flex.flex-col.grow-1
-                small
-                  b #{commenters[comment.author_id].username} 
-                  | #{formatDate(comment.created_at)}
-                .comment( data-val=comment.body )
-
-        br
-        hr
-        br
-
-        if contextUser && (universe.author_permissions[contextUser.id] >= (universe.discussion_open ? perms.READ : perms.COMMENT))
-          form( method='POST' action=`/universes/${universe.shortname}/items/${item.shortname}/comment` )
-            div
-              textarea( id='body' name='body' value=`${comment || ''}` )
-            div
-              button( type='submit' ) Post Comment
-            if error
-              div
-                span( style={'font-size': 'small'} ).color-error= error
+        include ../components/comments.pug
 
     if 'body' in item.obj_data
       .sheet.hidden( data-tab='body' )

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -67,6 +67,9 @@ block content
     if 'lineage' in item.obj_data && 'title' in item.obj_data.lineage
       li.navbarBtn( data-tab='lineage' )
           h3.navbarBtnLink.navbarText( onclick=`showTab('lineage')` ) #{item.obj_data.lineage.title}
+    if 'comments' in item.obj_data
+      li.navbarBtn( data-tab='comments' )
+          h3.navbarBtnLink.navbarText( onclick=`showTab('comments')` ) #{capitalize(T('comments'))}
 
   
   script!= `window.item = ${JSON.stringify(item)};`
@@ -117,6 +120,32 @@ block content
             hr
             a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/items/${shortname}` )
               | #{item.child_titles[shortname]}
+        
+    if 'comments' in item.obj_data
+      .hidden( data-tab='comments' )
+        .d-flex.flex-col.gap-4
+          each comment in comments
+            .sheet.d-flex.gap-4.align-start
+              img.userIcon( alt=commenters[comment.author_id].username, src=commenters[comment.author_id].gravatarLink )
+              .d-flex.flex-col.grow-1
+                small
+                  b #{commenters[comment.author_id].username} 
+                  | #{formatDate(comment.created_at)}
+                .comment( data-val=comment.body )
+
+        br
+        hr
+        br
+
+        if contextUser && (universe.author_permissions[contextUser.id] >= perms.COMMENT)
+          form( method='POST' action=`/universes/${universe.shortname}/items/${item.shortname}/comment` )
+            div
+              textarea( id='body' name='body' value=`${comment || ''}` )
+            div
+              button( type='submit' ) Post Comment
+            if error
+              div
+                span( style={'font-size': 'small'} ).color-error= error
 
     if 'body' in item.obj_data
       .sheet.hidden( data-tab='body' )
@@ -130,24 +159,29 @@ block content
     const body = document.getElementById('markdown-body');
     if (body) {
       loadMarkdown(body, '#{universe.shortname}', item.obj_data.body, { item });
-
-      document.querySelectorAll('.mdVal').forEach((el) => {
-        loadMarkdown(el, '#{universe.shortname}', el.dataset.val, null, (tag) => {
-          if (tag.type === 'div') tag.attrs.style = {'text-align': 'right'};
-          if (tag.type === 'p') tag.type = 'span';
-        });
-      });
-
-      document.querySelectorAll('.mdLabel').forEach((el) => {
-        loadMarkdown(el, '#{universe.shortname}', el.dataset.val, null, (tag) => {
-          if (tag.type === 'div') {
-            tag.attrs.style = {'text-align': 'center'};
-            tag.attrs.class += ' label';
-          }
-          if (tag.type === 'p') tag.type = 'span';
-        });
-      });
     };
+
+    document.querySelectorAll('.mdVal').forEach((el) => {
+      loadMarkdown(el, '#{universe.shortname}', el.dataset.val, null, (tag) => {
+        if (tag.type === 'div') tag.attrs.style = {'text-align': 'right'};
+        if (tag.type === 'p') tag.type = 'span';
+      });
+    });
+
+    document.querySelectorAll('.mdLabel').forEach((el) => {
+      loadMarkdown(el, '#{universe.shortname}', el.dataset.val, null, (tag) => {
+        if (tag.type === 'div') {
+          tag.attrs.style = {'text-align': 'center'};
+          tag.attrs.class += ' label';
+        }
+        if (tag.type === 'p') tag.type = 'span';
+      });
+    });
+    
+    document.querySelectorAll('.comment').forEach((el) => {
+      console.log(el.dataset.val)
+      loadMarkdown(el, '#{universe.shortname}', el.dataset.val, null);
+    });
   
   if contextUser && (universe.author_permissions[contextUser.id] >= perms.WRITE)
     script!= `loadEditor(${JSON.stringify(universe)}, ${JSON.stringify(item.obj_data.body)});`

--- a/templates/view/universe.pug
+++ b/templates/view/universe.pug
@@ -77,6 +77,9 @@ block content
     if !universe.public
       li.navbarBtn#bodyBtn( data-tab='viewers' )
         h3.navbarBtnLink.navbarText( onclick=`showTab('viewers')` ) Viewers
+    if universe.discussion_enabled
+      li.navbarBtn#bodyBtn( data-tab='discuss' )
+        h3.navbarBtnLink.navbarText( onclick=`showTab('discuss')` ) Discuss
 
   .tabs
     .container.hidden( data-tab='items' )
@@ -95,7 +98,7 @@ block content
     
     .card-list.hidden( data-tab='authors' )
       each username, id in universe.authors
-        if universe.author_permissions[id] > perms.READ
+        if universe.author_permissions[id] >= perms.WRITE
           .card.sheet.gap-4( onclick=`goTo('${ADDR_PREFIX}/users/${username}')` )
             img.userIcon( alt=username, src=authors[id].gravatarLink )
             .d-flex.flex-col.grow-1
@@ -117,7 +120,7 @@ block content
     
     .card-list.hidden( data-tab='viewers' )
       each username, id in universe.authors
-        if universe.author_permissions[id] === perms.READ
+        if universe.author_permissions[id] < perms.WRITE && universe.author_permissions[id] >= perms.READ
           .card.sheet.gap-4( onclick=`goTo('${ADDR_PREFIX}/users/${username}')` )
             img.userIcon( alt=username, src=authors[id].gravatarLink )
             .d-flex.flex-col.grow-1
@@ -129,4 +132,22 @@ block content
               span 
                 b #{T('Last seen')}: 
                 | #{formatDate(authors[id].updated_at)}
+    
+    .d-flex.flex-col.gap-4.hidden( data-tab='discuss' )
+      div
+        a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/discuss/create` ) Create New
+      each thread in threads
+        .sheet.d-flex.flex-col.gap-2.align-start( onclick=`goTo('${ADDR_PREFIX}/universes/${universe.shortname}/discuss/${thread.id}')` )
+          h2.ma-0
+            a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/discuss/${thread.id}` ) #{thread.title}
+          .d-flex.gap-4.flex-wrap
+            span
+              b #{T('Comments')}: 
+              | #{thread.comment_count}
+            span
+              b #{T('Created')}: 
+              | #{formatDate(thread.first_activity)}
+            span 
+              b #{T('Last activity')}: 
+              | #{formatDate(thread.last_activity)}
         

--- a/templates/view/universeThread.pug
+++ b/templates/view/universeThread.pug
@@ -21,31 +21,9 @@ block scripts
 block content
   h2 #{thread.title}
 
-  .d-flex.flex-col.gap-4
-    each comment in comments
-      .sheet.d-flex.gap-4.align-start
-        img.userIcon( alt=commenters[comment.author_id].username, src=commenters[comment.author_id].gravatarLink )
-        .d-flex.flex-col.grow-1
-          small
-            b #{commenters[comment.author_id].username} 
-            | #{formatDate(comment.created_at)}
-          .comment( data-val=comment.body )
+  include ../components/comments.pug
 
   script.
     document.querySelectorAll('.comment').forEach((el) => {
       loadMarkdown(el, '#{universe.shortname}', el.dataset.val, null);
     });
-
-  br
-  hr
-  br
-
-  if contextUser && (universe.author_permissions[contextUser.id] >= (universe.discussion_open ? perms.READ : perms.COMMENT))
-    form( method='POST' action=`/universes/${universe.shortname}/discuss/${thread.id}/comment` )
-      div
-        textarea( id='body' name='body' value=`${comment || ''}` )
-      div
-        button( type='submit' ) Post Comment
-      if error
-        div
-          span( style={'font-size': 'small'} ).color-error= error

--- a/templates/view/universeThread.pug
+++ b/templates/view/universeThread.pug
@@ -40,7 +40,7 @@ block content
   hr
   br
 
-  if contextUser && (universe.author_permissions[contextUser.id] >= perms.COMMENT)
+  if contextUser && (universe.author_permissions[contextUser.id] >= (universe.discussion_open ? perms.READ : perms.COMMENT))
     form( method='POST' action=`/universes/${universe.shortname}/discuss/${thread.id}/comment` )
       div
         textarea( id='body' name='body' value=`${comment || ''}` )

--- a/templates/view/universeThread.pug
+++ b/templates/view/universeThread.pug
@@ -1,0 +1,50 @@
+extends ../layout.pug
+
+block breadcrumbs
+  a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
+  |  / 
+  a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
+  |  / 
+  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
+  |  / 
+  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/discuss` ) #{T('Discuss')}
+  |  / 
+  span #{T('New')}
+
+block scripts
+  script
+    include /static/scripts/domUtils.js
+    include /static/scripts/fetchUtils.js
+    include /static/scripts/markdown/parse.js
+    include /static/scripts/markdown/render.js
+
+block content
+  h2 #{thread.title}
+
+  .d-flex.flex-col.gap-4
+    each comment in comments
+      .sheet.d-flex.gap-4.align-start
+        img.userIcon( alt=commenters[comment.author_id].username, src=commenters[comment.author_id].gravatarLink )
+        .d-flex.flex-col.grow-1
+          small
+            b #{commenters[comment.author_id].username}
+          .comment( data-val=comment.body )
+
+  script.
+    document.querySelectorAll('.comment').forEach((el) => {
+      loadMarkdown(el, '#{universe.shortname}', el.dataset.val, null);
+    });
+
+  br
+  hr
+  br
+
+  if contextUser && (universe.author_permissions[contextUser.id] >= perms.COMMENT)
+    form( method='POST' )
+      div
+        textarea( id='body' name='body' value=`${comment || ''}` )
+      div
+        button( type='submit' ) Post Comment
+      if error
+        div
+          span( style={'font-size': 'small'} ).color-error= error

--- a/templates/view/universeThread.pug
+++ b/templates/view/universeThread.pug
@@ -41,7 +41,7 @@ block content
   br
 
   if contextUser && (universe.author_permissions[contextUser.id] >= perms.COMMENT)
-    form( method='POST' )
+    form( method='POST' action=`/universes/${universe.shortname}/discuss/${thread.id}/comment` )
       div
         textarea( id='body' name='body' value=`${comment || ''}` )
       div

--- a/templates/view/universeThread.pug
+++ b/templates/view/universeThread.pug
@@ -7,7 +7,7 @@ block breadcrumbs
   |  / 
   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
   |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/discuss` ) #{T('Discuss')}
+  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}?tab=discuss` ) #{T('Discuss')}
   |  / 
   span #{T('New')}
 
@@ -27,7 +27,8 @@ block content
         img.userIcon( alt=commenters[comment.author_id].username, src=commenters[comment.author_id].gravatarLink )
         .d-flex.flex-col.grow-1
           small
-            b #{commenters[comment.author_id].username}
+            b #{commenters[comment.author_id].username} 
+            | #{formatDate(comment.created_at)}
           .comment( data-val=comment.body )
 
   script.

--- a/views.js
+++ b/views.js
@@ -148,6 +148,7 @@ module.exports = function(app) {
       ...req.body,
       obj_data: decodeURIComponent(req.body.obj_data),
       public: req.body.visibility === 'public',
+      discussion_enabled: req.body.discussion_enabled === 'enabled',
     });
     res.status(code);
     if (code === 201) return res.redirect(`${ADDR_PREFIX}/universes/${req.body.shortname}`);
@@ -189,6 +190,7 @@ module.exports = function(app) {
       ...req.body,
       obj_data: decodeURIComponent(req.body.obj_data),
       public: req.body.visibility === 'public',
+      discussion_enabled: req.body.discussion_enabled === 'enabled',
     }
     const [code, data] = await api.universe.put(req.session.user, req.params.shortname, req.body);
     res.status(code);

--- a/views.js
+++ b/views.js
@@ -169,7 +169,7 @@ module.exports = function(app) {
         gravatarLink: `https://www.gravatar.com/avatar/${md5(author.email)}.jpg`,
       };
     });
-    const [code3, threads] = await api.discussion.getThreads(req.session.user, { 'universethread.universe_id': universe.id }, perms.READ, true);
+    const [code3, threads] = await api.discussion.getThreads(req.session.user, { 'discussion.universe_id': universe.id }, perms.READ, true);
     if (!threads) return [code3];
     res.prepareRender('universe', { universe, authors: authorMap, threads });
   });
@@ -211,7 +211,7 @@ module.exports = function(app) {
     res.status(code1);
     if (code1 === 201) {
       if (req.body.comment) {
-        const [code2, _] = await api.discussion.postComment(req.session.user, data.insertId, { body: req.body.comment });
+        const [code2, _] = await api.discussion.postCommentToThread(req.session.user, data.insertId, { body: req.body.comment });
         res.status(code2);
       }
       return res.redirect(`${ADDR_PREFIX}/universes/${req.params.shortname}/discuss/${data.insertId}`);
@@ -229,7 +229,7 @@ module.exports = function(app) {
     if (!threads) return [code2];
     const thread = threads[0];
     if (!thread) return [code2];
-    const [code3, comments, users] = await api.discussion.getComments(req.session.user, thread.id, false, true);
+    const [code3, comments, users] = await api.discussion.getCommentsByThread(req.session.user, thread.id, false, true);
     if (!comments || !users) return [code3];
     const commenters = {};
     for (const user of users) {
@@ -241,7 +241,7 @@ module.exports = function(app) {
     res.prepareRender('universeThread', { universe, thread, comments, commenters });
   });
   post('/universes/:shortname/discuss/:threadId', Auth.verifySessionOrRedirect, async (req, res) => {
-    const [code, _] = await api.discussion.postComment(req.session.user, req.params.threadId, req.body);
+    const [code, _] = await api.discussion.postCommentToThread(req.session.user, req.params.threadId, req.body);
     res.status(code);
     return res.redirect(`${ADDR_PREFIX}/universes/${req.params.shortname}/discuss/${req.params.threadId}`);
   });

--- a/views.js
+++ b/views.js
@@ -169,7 +169,9 @@ module.exports = function(app) {
         gravatarLink: `https://www.gravatar.com/avatar/${md5(author.email)}.jpg`,
       };
     });
-    res.prepareRender('universe', { universe, authors: authorMap });
+    const [code3, threads] = await api.discussion.getThreads(req.session.user, { 'universethread.universe_id': universe.id }, perms.READ, true);
+    if (!threads) return [code3];
+    res.prepareRender('universe', { universe, authors: authorMap, threads });
   });
 
   get('/universes/:shortname/delete', Auth.verifySessionOrRedirect, async (req, res) => {

--- a/views.js
+++ b/views.js
@@ -149,6 +149,7 @@ module.exports = function(app) {
       obj_data: decodeURIComponent(req.body.obj_data),
       public: req.body.visibility === 'public',
       discussion_enabled: req.body.discussion_enabled === 'enabled',
+      discussion_open: req.body.discussion_open === 'enabled',
     });
     res.status(code);
     if (code === 201) return res.redirect(`${ADDR_PREFIX}/universes/${req.body.shortname}`);
@@ -169,7 +170,7 @@ module.exports = function(app) {
         gravatarLink: `https://www.gravatar.com/avatar/${md5(author.email)}.jpg`,
       };
     });
-    const [code3, threads] = await api.discussion.getThreads(req.session.user, { 'discussion.universe_id': universe.id }, perms.READ, true);
+    const [code3, threads] = await api.discussion.getThreads(req.session.user, { 'discussion.universe_id': universe.id }, false, true);
     if (!threads) return [code3];
     res.prepareRender('universe', { universe, authors: authorMap, threads });
   });
@@ -193,6 +194,7 @@ module.exports = function(app) {
       obj_data: decodeURIComponent(req.body.obj_data),
       public: req.body.visibility === 'public',
       discussion_enabled: req.body.discussion_enabled === 'enabled',
+      discussion_open: req.body.discussion_open === 'enabled',
     }
     const [code, data] = await api.universe.put(req.session.user, req.params.shortname, req.body);
     res.status(code);

--- a/views.js
+++ b/views.js
@@ -240,7 +240,10 @@ module.exports = function(app) {
       commenters[user.id] = user;
     }
     
-    res.prepareRender('universeThread', { universe, thread, comments, commenters });
+    res.prepareRender('universeThread', { 
+      universe, thread, comments, commenters,
+      commentAction: `/universes/${universe.shortname}/discuss/${thread.id}/comment`,
+    });
   });
   post('/universes/:shortname/discuss/:threadId/comment', Auth.verifySessionOrRedirect, async (req, res) => {
     const [code, _] = await api.discussion.postCommentToThread(req.session.user, req.params.threadId, req.body);
@@ -314,7 +317,10 @@ module.exports = function(app) {
       delete user.email;
       commenters[user.id] = user;
     }
-    res.prepareRender('item', { item, universe, tab: req.query.tab, comments, commenters });
+    res.prepareRender('item', {
+      item, universe, tab: req.query.tab, comments, commenters,
+      commentAction: `/universes/${universe.shortname}/items/${item.shortname}/comment`,
+    });
   });
   get('/universes/:universeShortname/items/:itemShortname/edit', Auth.verifySessionOrRedirect, async (req, res) => {
     const [code1, item] = await api.item.getByUniverseAndItemShortnames(req.session.user, req.params.universeShortname, req.params.itemShortname, perms.WRITE);


### PR DESCRIPTION
closes #42 

- Add a `COMMENT` permission level. This is a **breaking change** and the following fixes will have to be made to the database:
```sql
UPDATE authoruniverse SET permission_level = 4 WHERE permission_level = 3;
UPDATE authoruniverse SET permission_level = 3 WHERE permission_level = 2;
```
- Allow enabling or disabling discussion for universes. If discussion is enabled, show a "Discuss" tab on the universe page.
- If discussion is enabled, also allow restricting if `COMMENT` permission level is needed to comment for this universe.
- Add discussion thread page, where comments on a discussion thread are displayed and new ones can be added.
![image](https://github.com/user-attachments/assets/c49489dd-ad55-4df4-a9ee-76b9aaeb35d9)
![image](https://github.com/user-attachments/assets/cacdfac1-7c6d-43b7-ba21-45896ff21d5c)
- Add "Comments" tab that can be added to items. If present, display and allow posting of comments on that item.

Still to do:
- Support "replying" to a comment
- Allow comment deletion
- @mentions and notifications?
- Maybe emojis and reactions if we wanna be fancy