### PR TITLE
Update how snoozing works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ db/backups/
 logs/
 
 elm/elm-stuff/
+
+cypress/screenshots/

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -103,7 +103,7 @@ CREATE TABLE itemimage (
 );
 
 CREATE TABLE snooze (
-  snoozed_until TIMESTAMP NOT NULL,
+  snoozed_at TIMESTAMP NOT NULL,
   snoozed_by INT NOT NULL,
   item_id INT NOT NULL,
   FOREIGN KEY (snoozed_by) REFERENCES user (id),

--- a/static/scripts/markdown/parse.js
+++ b/static/scripts/markdown/parse.js
@@ -218,7 +218,7 @@ if (!window.getJSON) throw 'fetchUtils.js not loaded!';
       const [src, alt, height, width] = args;
       const attrs = {
         ctx: {
-          src: isNaN(Number(src)) ? src : new GalleryUrl(new CtxLookup('item', 'gallery', src, 0)),
+          src: isNaN(Number(src)) ? src : new GalleryUrl(new CtxLookup('item', 'gallery', src, 'id')),
           title: alt || new CtxLookup('item', 'gallery', src, 1).default(alt),
           alt: alt || new CtxLookup('item', 'gallery', src, 2).default(alt),
         },

--- a/templates/components/comments.pug
+++ b/templates/components/comments.pug
@@ -14,7 +14,7 @@ div
   hr
   br
 
-  if contextUser && (universe.author_permissions[contextUser.id] >= (universe.discussion_open ? perms.READ : perms.COMMENT))
+  if contextUser && ((universe.public && universe.discussion_open) || (universe.author_permissions[contextUser.id] >= (universe.discussion_open ? perms.READ : perms.COMMENT)))
     form( method='POST' action=commentAction )
       .editor( data-replicated-value='' )
         textarea.comment-field( id='body' name='body' oninput="t" )

--- a/templates/home.pug
+++ b/templates/home.pug
@@ -8,9 +8,12 @@ block content
     function snooze(universe, item) {
       if (reloading) return;
       fetch(`/api/universes/${universe}/items/${item}/snooze`, { method: 'PUT' });
-      document.querySelector(`[data-item=${item}]`).parentNode.parentNode.parentNode.remove();
+      document.querySelector(`[data-item=${item}]`).parentNode.parentNode.parentNode.querySelectorAll('td').forEach(td => {
+        td.style.opacity = 0;
+      });
       if (snoozeTimeout) clearTimeout(snoozeTimeout);
       snoozeTimeout = setTimeout(() => {
+        document.querySelectorAll('[data-item]').forEach(button => button.disabled = true);
         reloading = true;
         window.location.reload();
       }, 1000);
@@ -81,7 +84,7 @@ block content
                 td
                   .d-flex.gap-1
                     button.pa-1( onclick=`snooze('${item.universe_short}', '${item.shortname}')` data-item=item.shortname )
-                      small Snooze
+                      small Dismiss
                     a.big-text.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}/items/${item.shortname}` ) #{item.title}
                 td
                   small

--- a/views.js
+++ b/views.js
@@ -310,7 +310,7 @@ module.exports = function(app) {
     item.obj_data = JSON.parse(item.obj_data);
     item.itemTypeName = ((universe.obj_data.cats ?? {})[item.item_type] ?? ['missing_cat'])[0];
     if (item.gallery.length > 0) {
-      item.gallery = item.gallery.sort((a, b) => a[0] > b[0] ? 1 : -1);
+      item.gallery = item.gallery.sort((a, b) => a.id > b.id ? 1 : -1);
     }
     const [code3, comments, users] = await api.discussion.getCommentsByItem(req.session.user, item.id, false, true);
     if (!comments || !users) return [code3];

--- a/views.js
+++ b/views.js
@@ -65,11 +65,13 @@ module.exports = function(app) {
       }) : [200, []];
       res.status(code3);
       const [code4, oldestUpdated] = await api.item.getMany(user, null, perms.WRITE, {
-        sort: 'updated_at',
+        sort: `GREATEST(IFNULL(snooze.snoozed_at, '1000-01-01'), IFNULL(item.updated_at, '1000-01-01'))`,
         sortDesc: false,
+        forceSort: true,
         limit: 16,
         join: [['LEFT', 'snooze', new Cond('snooze.item_id = item.id').and('snooze.snoozed_by = ?', user.id)]],
-        where: new Cond('snooze.snoozed_until < NOW()').or('snooze.snoozed_until IS NULL').and('item.updated_at < DATE_SUB(NOW(), INTERVAL 2 DAY)'),
+        where: new Cond('item.updated_at < DATE_SUB(NOW(), INTERVAL 2 DAY)'),
+        groupBy: ['snooze.snoozed_at'],
       });
       res.status(code4);
       if (!oldestUpdated) return;


### PR DESCRIPTION
Instead of snoozing an item in the "Needs Review" list and hiding it for a few days, it essentially just sends it to the back of the list. Also applies the following hotfixes:
- Fix gallery images being out of order
- Fix rendering gallery images in markdown
- Fix not being able to comment on public universes even if discussion is open

I haven't figured out a good way to make cypress tests for the home page yet, since it depends on significant amounts of time to pass.

Column `snooze.snoozed_until` changed name to `snooze.snoozed_at`, this will have to be taken into account when loading the new schema.