### PR TITLE
Add Notes

### DIFF
--- a/api/models/note.js
+++ b/api/models/note.js
@@ -1,28 +1,93 @@
+const crypto = require('crypto');
 const { executeQuery, parseData, perms } = require('../utils');
 const logger = require('../../logger');
 const itemapi = require('./item');
+const universeapi = require('./universe');
+const userapi = require('./user');
 
-async function getNotesByItem(user, itemId, validate=true, inclAuthors=false) {
+async function getOne(user, uuid) {
+  // Direct note access is only allowed for our own notes.
+  if (!user) return [401];
+
   try {
-    if (validate) {
-      const [code, item] = await itemapi.getOne(user, itemId, permissionLevel, true);
-      if (!item) return [code];
-    }
-    const queryString1 = `
-      SELECT note.*
+    const note = (await getMany(user, { 'note.uuid': uuid }, { limit: 1, inclBody: true }))[0];
+    if (!note) return [404];
+    if (note.author_id !== user.id) return [403];
+    return [200, note];
+  } catch (err) {
+    logger.error(err);
+    return [500];
+  }
+}
+
+/**
+ * This should never be called on it's own.
+ * Users should only have access to notes in one of the following ways:
+ * * they own the note,
+ * * they have access to a board this note is pinned to, or,
+ * * they have write access to an item this note is linked to.
+ * @param {*} user 
+ * @param {*} conditions 
+ * @param {*} options 
+ * @returns 
+ */
+async function getMany(user, conditions, options) {
+  try {
+    const parsedConds = parseData(conditions ?? {});
+    parsedConds.strings.push('(note.public OR note.author_id = ?)');
+    parsedConds.values.push(user?.id);
+    const queryString = `
+      SELECT
+        note.id, note.uuid, note.title,
+        note.public, note.author_id,
+        note.created_at, note.updated_at
+      ${options?.inclBody ? ', note.body' : ''}
       FROM note
-      INNER JOIN itemnote AS in ON in.note_id = note.id
-      WHERE in.item_id = ?`;
-    const notes = await executeQuery(queryString1, [ itemId ]);
+      ${options?.join ?? ''}
+      WHERE ${parsedConds.strings.join(' AND ')}
+      ${options?.limit ? `LIMIT ${options.limit}` : ''}
+    `;
+    const notes = await executeQuery(queryString, parsedConds.values);
+    return [200, notes];
+  } catch (err) {
+    logger.error(err);
+    return [500];
+  }
+}
+
+async function getByUsername(sessionUser, username, conditions) {
+  try {
+    const [code, user] = await userapi.getOne({ 'user.username': username });
+    if (!user) return [code];
+    const [_, notes] = await getMany(
+      sessionUser,
+      { ...(conditions ?? {}), 'note.author_id': user.id },
+    );
+    return [200, notes];
+  } catch (err) {
+    logger.error(err);
+    return [500];
+  }
+}
+
+async function getByItemShortname(user, universeShortname, itemShortname, conditions={}, validate=true, inclAuthors=false) {
+  try {
+    const [code, item] = await itemapi.getByUniverseAndItemShortnames(user, universeShortname, itemShortname, perms.WRITE, true);
+    if (!item) return [code];
+    const [_, notes] = await getMany(
+      user,
+      { ...conditions, 'itemnote.item_id': user?.id },
+      { join: 'INNER JOIN itemnote ON itemnote.note_id = note.id' },
+    );
     if (inclAuthors) {
       const queryString2 = `
         SELECT user.id, user.username, user.email
         FROM user
         INNER JOIN note ON user.id = note.author_id
-        INNER JOIN itemnote AS in ON in.note_id = note.id
-        WHERE in.item_id = ?
+        INNER JOIN itemnote ON itemnote.note_id = note.id
+        WHERE itemnote.item_id = ?
         GROUP BY user.id`;
-      const users = await executeQuery(queryString2, [ itemId ]);
+      const users = await executeQuery(queryString2, [ item.id ]);
       return [200, notes, users];
     }
     return [200, notes];
@@ -32,16 +97,57 @@ async function getNotesByItem(user, itemId, validate=true, inclAuthors=false) {
   }
 }
 
-async function postNoteToItem(user, universeShortname, itemShortname, bodyText) {
-  const [code, item] = await itemapi.getByUniverseAndItemShortnames(user, universeShortname, itemShortname, perms.COMMENT, true)
-  if (!item) return [code];
-  if (!body) return [400];
-
+async function getBoardsByUniverseShortname(user, shortname) {
   try {
-    const queryString1 = `INSERT INTO note (body, author_id, created_at, updated_at) VALUES (?, ?, ?, ?);`;
-    const data = await executeQuery(queryString1, [ bodyText, user.id, new Date(), new Date() ]);
-    const queryString2 = `INSERT INTO itemnote (item_id, note_id) VALUES (?, ?)`;
-    await executeQuery(queryString2, [ item.id, data.insertId ])
+    const [code, universe] = await universeapi.getOne(user, { 'universe.shortname': shortname }, perms.WRITE);
+    if (!universe) return [code];
+    const boards = await executeQuery('SELECT * FROM noteboard WHERE universe_id = ?', [ universe.id ]);
+    return [200, boards];
+  } catch (err) {
+    logger.error(err);
+    return [500];
+  }
+}
+
+async function getByBoardShortname(user, shortname, conditions={}, validate=true, inclAuthors=false) {
+  try {
+    const board = await executeQuery('SELECT * FROM noteboard WHERE shortname = ?', [ shortname ]);
+    if (!board) return [404];
+    if (validate) {
+      const [code, universe] = await universeapi.getOne(user, { 'universe.id': board.universe_id }, perms.WRITE);
+      if (!universe) return [code];
+    }
+    const [_, notes] = await getMany(
+      user,
+      { ...conditions, 'boardnote.board_id': board.id },
+      { join: 'INNER JOIN boardnote ON boardnote.note_id = note.id' },
+    );
+    if (inclAuthors) {
+      const queryString2 = `
+        SELECT user.id, user.username, user.email
+        FROM user
+        INNER JOIN note ON user.id = note.author_id
+        INNER JOIN boardnote ON boardnote.note_id = note.id
+        WHERE boardnote.board_id = ?
+        GROUP BY user.id`;
+      const users = await executeQuery(queryString2, [ board.id ]);
+      return [200, notes, users];
+    }
+    return [200, notes];
+  } catch (err) {
+    logger.error(err);
+    return [500];
+  }
+}
+
+async function postBoard(user, { title, shortname }, universeShortname) {
+  if (!user) return [401];
+  try {
+    const [code, universe] = await universeapi.getOne(user, { 'universe.shortname': universeShortname }, perms.WRITE);
+    if (!universe) return [code];
+
+    const queryString = `INSERT INTO noteboard (title, shortname, universe_id) VALUES (?, ?, ?);`;
+    const data = await executeQuery(queryString, [ title, shortname, universe.id ]);
     return [201, data];
   } catch (err) {
     logger.error(err);
@@ -49,7 +155,64 @@ async function postNoteToItem(user, universeShortname, itemShortname, bodyText) 
   }
 }
 
+async function post(user, { title, body, public }) {
+  if (!user) return [401];
+  try {
+    const uuid = crypto.randomUUID();
+
+    const queryString = `INSERT INTO note (uuid, title, body, public, author_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?);`;
+    const data = await executeQuery(queryString, [ uuid, title, body, public, user.id, new Date(), new Date() ]);
+    return [201, data, uuid];
+  } catch (err) {
+    logger.error(err);
+    return [500];
+  }
+}
+
+async function linkToBoard(user, boardShortname, noteUuid) {
+  if (!noteUuid) return [400];
+  if (!user) return [401];
+  const board = await executeQuery('SELECT * FROM noteboard WHERE shortname = ?', [ boardShortname ]);
+  if (!board) return [404];
+  const [code2, note] = await getOne(user, { 'note.uuid': noteUuid });
+  if (!note) return [code2];
+
+  try {
+    const queryString = `INSERT INTO boardnote (board_id, note_id) VALUES (?, ?)`;
+    await executeQuery(queryString, [ board.id, note.id ])
+    return [201];
+  } catch (err) {
+    logger.error(err);
+    return [500];
+  }
+}
+
+async function linkToItem(user, universeShortname, itemShortname, noteUuid) {
+  if (!noteUuid) return [400];
+  if (!user) return [401];
+  const [code, item] = await itemapi.getByUniverseAndItemShortnames(user, universeShortname, itemShortname, perms.WRITE, true)
+  if (!item) return [code];
+  const [code2, note] = await getOne(user, { 'note.uuid': noteUuid });
+  if (!note) return [code2];
+
+  try {
+    const queryString = `INSERT INTO itemnote (item_id, note_id) VALUES (?, ?)`;
+    await executeQuery(queryString, [ item.id, note.id ])
+    return [201];
+  } catch (err) {
+    logger.error(err);
+    return [500];
+  }
+}
+
 module.exports = {
-  getNotesByItem,
-  postNoteToItem,
+  getOne,
+  getByUsername,
+  getByItemShortname,
+  getBoardsByUniverseShortname,
+  getByBoardShortname,
+  postBoard,
+  post,
+  linkToBoard,
+  linkToItem,
 };

--- a/api/models/note.js
+++ b/api/models/note.js
@@ -1,0 +1,55 @@
+const { executeQuery, parseData, perms } = require('../utils');
+const logger = require('../../logger');
+const itemapi = require('./item');
+
+async function getNotesByItem(user, itemId, validate=true, inclAuthors=false) {
+  try {
+    if (validate) {
+      const [code, item] = await itemapi.getOne(user, itemId, permissionLevel, true);
+      if (!item) return [code];
+    }
+    const queryString1 = `
+      SELECT note.*
+      FROM note
+      INNER JOIN itemnote AS in ON in.note_id = note.id
+      WHERE in.item_id = ?`;
+    const notes = await executeQuery(queryString1, [ itemId ]);
+    if (inclAuthors) {
+      const queryString2 = `
+        SELECT user.id, user.username, user.email
+        FROM user
+        INNER JOIN note ON user.id = note.author_id
+        INNER JOIN itemnote AS in ON in.note_id = note.id
+        WHERE in.item_id = ?
+        GROUP BY user.id`;
+      const users = await executeQuery(queryString2, [ itemId ]);
+      return [200, notes, users];
+    }
+    return [200, notes];
+  } catch (err) {
+    logger.error(err);
+    return [500];
+  }
+}
+
+async function postNoteToItem(user, universeShortname, itemShortname, bodyText) {
+  const [code, item] = await itemapi.getByUniverseAndItemShortnames(user, universeShortname, itemShortname, perms.COMMENT, true)
+  if (!item) return [code];
+  if (!body) return [400];
+
+  try {
+    const queryString1 = `INSERT INTO note (body, author_id, created_at, updated_at) VALUES (?, ?, ?, ?);`;
+    const data = await executeQuery(queryString1, [ bodyText, user.id, new Date(), new Date() ]);
+    const queryString2 = `INSERT INTO itemnote (item_id, note_id) VALUES (?, ?)`;
+    await executeQuery(queryString2, [ item.id, data.insertId ])
+    return [201, data];
+  } catch (err) {
+    logger.error(err);
+    return [500];
+  }
+}
+
+module.exports = {
+  getNotesByItem,
+  postNoteToItem,
+};

--- a/api/models/note.js
+++ b/api/models/note.js
@@ -73,7 +73,7 @@ async function getByUsername(sessionUser, username, conditions) {
 
 async function getByItemShortname(user, universeShortname, itemShortname, conditions={}, validate=true, inclAuthors=false) {
   try {
-    const [code, item] = await itemapi.getByUniverseAndItemShortnames(user, universeShortname, itemShortname, perms.WRITE, true);
+    const [code, item] = await itemapi.getByUniverseAndItemShortnames(user, universeShortname, itemShortname, perms.READ, true);
     if (!item) return [code];
     const [_, notes] = await getMany(
       user,

--- a/api/models/note.js
+++ b/api/models/note.js
@@ -181,13 +181,16 @@ async function postBoard(user, { title, shortname }, universeShortname) {
   }
 }
 
-async function post(user, { title, body, public }) {
+async function post(user, { title, body, public, tags }) {
   if (!user) return [401];
   try {
     const uuid = crypto.randomUUID();
 
     const queryString = `INSERT INTO note (uuid, title, body, public, author_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?);`;
     const data = await executeQuery(queryString, [ uuid, title, body, public, user.id, new Date(), new Date() ]);
+
+    putTags(user, uuid, tags);
+
     return [201, data, uuid];
   } catch (err) {
     logger.error(err);

--- a/api/models/note.js
+++ b/api/models/note.js
@@ -24,10 +24,10 @@ async function getOne(user, uuid) {
 
 /**
  * This should never be called on it's own.
- * Users should only have access to notes in one of the following ways:
+ * Users should have access to notes iff:
  * * they own the note,
  * * they have access to a board this note is pinned to, or,
- * * they have write access to an item this note is linked to.
+ * * they have access to an item this note is linked to.
  * @param {*} user 
  * @param {*} conditions 
  * @param {*} options 

--- a/api/models/note.js
+++ b/api/models/note.js
@@ -36,8 +36,12 @@ async function getOne(user, uuid) {
 async function getMany(user, conditions, options) {
   try {
     const parsedConds = parseData(conditions ?? {});
-    parsedConds.strings.push('(note.public OR note.author_id = ?)');
-    parsedConds.values.push(user?.id);
+    if (user) {
+      parsedConds.strings.push('(note.public OR note.author_id = ?)');
+      parsedConds.values.push(user.id);
+    } else {
+      parsedConds.strings.push('note.public');
+    }
     const queryString = `
       SELECT
         note.id, note.uuid, note.title,

--- a/api/models/universe.js
+++ b/api/models/universe.js
@@ -53,7 +53,7 @@ async function getMany(user, conditions, permissionLevel=perms.READ) {
   }
 }
 
-function getManyByAuthorId(user, authorId) {
+function getManyByAuthorId(user, authorId, permissionLevel=perms.WRITE) {
   return getMany(user, {
     strings: [`
       EXISTS (
@@ -64,7 +64,7 @@ function getManyByAuthorId(user, authorId) {
       )
     `], values: [
       authorId,
-      perms.READ,
+      permissionLevel,
     ] 
   });
 }

--- a/api/models/universe.js
+++ b/api/models/universe.js
@@ -19,6 +19,7 @@ async function getOne(user, options, permissionLevel=perms.READ) {
  */
 async function getMany(user, conditions, permissionLevel=perms.READ) {
   try {
+    if (!user && permissionLevel > perms.READ) return [400];
     const readOnlyQueryString = permissionLevel > perms.READ ? '' : `universe.public = 1`;
     const usrQueryString = user ? `(au_filter.user_id = ${user.id} AND au_filter.permission_level >= ${permissionLevel})` : '';
     const permsQueryString = `${readOnlyQueryString}${(readOnlyQueryString && usrQueryString) ? ' OR ' : ''}${usrQueryString}`;

--- a/api/routes.js
+++ b/api/routes.js
@@ -119,7 +119,7 @@ module.exports = function(app, upload) {
           }, [
             new APIRoute('/:uuid', {
               GET: (req) => frmtData(
-                api.note.getByBoardShortname(req.session.user, req.params.boardShortname, { 'note.uuid': req.params.uuid }),
+                api.note.getByBoardShortname(req.session.user, req.params.boardShortname, { 'note.uuid': req.params.uuid }, { fullBody: true }),
                 (notes) => notes[0],
               ),
             }),
@@ -143,7 +143,13 @@ module.exports = function(app, upload) {
             }, [
               new APIRoute('/:uuid', {
                 GET: (req) => frmtData(
-                  api.note.getByItemShortname(req.session.user, req.params.universeShortName, req.params.itemShortName, { 'note.uuid': req.params.uuid }),
+                  api.note.getByItemShortname(
+                    req.session.user,
+                    req.params.universeShortName,
+                    req.params.itemShortName,
+                    { 'note.uuid': req.params.uuid },
+                    { fullBody: true },
+                  ),
                   (notes) => notes[0],
                 ),
               }),

--- a/api/routes.js
+++ b/api/routes.js
@@ -58,6 +58,14 @@ module.exports = function(app, upload) {
     new APIRoute('/users', { GET: () => api.user.getMany() }, [
       new APIRoute('/:username', { GET: (req) => api.user.getOne({ 'user.username': req.params.username }) }, [
         new APIRoute('/send-verify-link', { GET: (req) => email.trySendVerifyLink(req.session.user, req.params.username) }),
+        new APIRoute('/notes', {
+          GET: (req) => api.note.getByUsername(req.session.user, req.params.username),
+          POST: (req) => api.note.post(req.session.user, req.body),
+        }, [
+          new APIRoute('/:uuid', {
+            GET: (req) => api.note.getOne(req.session.user, req.params.uuid),
+          }),
+        ]),
         new APIRoute('/universes', {
           GET: async (req) => {
             const [code, user] = await api.user.getOne({ 'user.username': req.params.username });
@@ -101,6 +109,22 @@ module.exports = function(app, upload) {
         GET: (req) => api.universe.getOne(req.session.user, { shortname: req.params.universeShortName }),
         DELETE: (req) => api.universe.del(req.session.user, req.params.universeShortName),
       }, [
+        new APIRoute('/notes', {
+          GET: (req) => api.note.getBoardsByUniverseShortname(req.session.user, req.params.universeShortName),
+          POST: (req) => api.note.postBoard(req.session.user, req.body, req.params.universeShortName),
+        }, [
+          new APIRoute('/:boardShortname', {
+            GET: (req) => api.note.getByBoardShortname(req.session.user, req.params.boardShortname),
+            POST: (req) => api.note.linkToBoard(req.session.user, req.params.boardShortname, req.body.uuid),
+          }, [
+            new APIRoute('/:uuid', {
+              GET: (req) => frmtData(
+                api.note.getByBoardShortname(req.session.user, req.params.boardShortname, { 'note.uuid': req.params.uuid }),
+                (notes) => notes[0],
+              ),
+            }),
+          ]),
+        ]),
         new APIRoute('/items', {
           GET: (req) => api.item.getByUniverseShortname(req.session.user, req.params.universeShortName),
           POST: (req) => api.item.post(req.session.user, req.body, req.params.universeShortName),
@@ -109,6 +133,21 @@ module.exports = function(app, upload) {
             GET: async (req) => api.item.getByUniverseAndItemShortnames(req.session.user, req.params.universeShortName, req.params.itemShortName),
             PUT: async (req) => api.item.save(req.session.user, req.params.universeShortName, req.params.itemShortName, req.body, true),
           }, [
+            new APIRoute('/notes', {
+              GET: (req) => api.note.getByItemShortname(req.session.user, req.params.universeShortName, req.params.itemShortName),
+              POST: async (req) => {
+                const [code, data, uuid] = await api.note.post(req.session.user, req.body);
+                await api.note.linkToItem(req.session.user, req.params.universeShortName, req.params.itemShortName, uuid);
+                return [code, data];
+              },
+            }, [
+              new APIRoute('/:uuid', {
+                GET: (req) => frmtData(
+                  api.note.getByItemShortname(req.session.user, req.params.universeShortName, req.params.itemShortName, { 'note.uuid': req.params.uuid }),
+                  (notes) => notes[0],
+                ),
+              }),
+            ]),
             new APIRoute('/data', {
               PUT: (req) => api.item.putData(req.session.user, req.params.universeShortName, req.params.itemShortName, req.body),
             }),

--- a/cypress/e2e/anonymous_spec.cy.js
+++ b/cypress/e2e/anonymous_spec.cy.js
@@ -17,6 +17,7 @@ describe('Anonymous user spec', () => {
       '/search',
       '/universes/public-test-universe',
       '/universes/public-test-universe/items',
+      '/universes/public-test-universe/items/test-article',
       '/universes/public-test-universe/items/test-character',
     ];
     for (const page of pages) {

--- a/cypress/e2e/anonymous_spec.cy.js
+++ b/cypress/e2e/anonymous_spec.cy.js
@@ -22,6 +22,7 @@ describe('Anonymous user spec', () => {
     for (const page of pages) {
       cy.visit(page);
       cy.url().should('include', Cypress.config().baseUrl + page);
+      cy.get('.error').should('not.exist');
     }
   });
 

--- a/cypress/e2e/item_spec.cy.js
+++ b/cypress/e2e/item_spec.cy.js
@@ -69,45 +69,44 @@ describe('Item spec', () => {
     cy.get('.timeline>.flex-col').children().should('have.length', timelineEvents);
   });
 
-  // TODO Reenable this and the following test once #73 is fixes
-  // it('adds an event to an item, then imports it to the timeline', () => {
-  //   cy.visit('/universes/public-test-universe/items/test-event/edit');
+  it('adds an event to an item, then imports it to the timeline', () => {
+    cy.visit('/universes/public-test-universe/items/test-event/edit');
 
-  //   cy.get('.tabs-buttons').contains('Timeline').click();
-  //   cy.get('#new_event_title').type('Cypress Event');
-  //   cy.get('#new_event_time').siblings('button').click();
-  //   cy.get('#time-picker-new_event_time input').first().type('2007');
-  //   cy.get('#time-picker-new_event_time button').click();
-  //   cy.get('[data-tab="Timeline"] button').contains('Create New Event').click();
-  //   cy.get('#save-btn').click();
+    cy.get('.tabs-buttons').contains('Timeline').click();
+    cy.get('#new_event_title').type('Cypress Event');
+    cy.get('#new_event_time').siblings('button').click();
+    cy.get('#time-picker-new_event_time input').first().type('2007');
+    cy.get('#time-picker-new_event_time button').click();
+    cy.get('[data-tab="Timeline"] button').contains('Create New Event').click();
+    cy.get('#save-btn').click();
 
-  //   cy.visit('/universes/public-test-universe/items/test-timeline/edit');
+    cy.visit('/universes/public-test-universe/items/test-timeline/edit');
 
-  //   cy.get('.tabs-buttons').contains('Timeline').click();
-  //   cy.get('[data-tab="Timeline"] button').contains('Import Event').click();
-  //   cy.get('#import-event-item').siblings('input').type('Test Event');
-  //   cy.get('#import-event-item').siblings('div').find('div').filter(':visible').first().click();
-  //   cy.get('#import-event-event').siblings('input').type('Cypress Event');
-  //   cy.get('#import-event-event').siblings('div').find('div').filter(':visible').first().click();
-  //   cy.get('#import-event button').contains('Import').click();
-  //   cy.get('#save-btn').click();
+    cy.get('.tabs-buttons').contains('Timeline').click();
+    cy.get('[data-tab="Timeline"] button').contains('Import Event').click();
+    cy.get('#import-event-item').siblings('input').type('Test Event');
+    cy.get('#import-event-item').siblings('div').find('div').filter(':visible').first().click();
+    cy.get('#import-event-event').siblings('input').type('Cypress Event');
+    cy.get('#import-event-event').siblings('div').find('div').filter(':visible').first().click();
+    cy.get('#import-event button').contains('Import').click();
+    cy.get('#save-btn').click();
 
-  //   cy.visit('/universes/public-test-universe/items/test-timeline?tab=timeline');
-  //   cy.get('.timeline>.flex-col').children().should('have.length', timelineEvents + 1);
-  //   cy.get('.timeline>.flex-col>div').first().should('contain', 'January 1st 2007, 0:00 — Cypress Event of Test Event');
-  // });
+    cy.visit('/universes/public-test-universe/items/test-timeline?tab=timeline');
+    cy.get('.timeline>.flex-col').children().should('have.length', timelineEvents + 1);
+    cy.get('.timeline>.flex-col>div').first().should('contain', 'January 1st 2007, 0:00 — Cypress Event of Test Event');
+  });
 
-  // it('deletes the event and sees that it is removed from the timeline that imported it as well', () => {
-  //   cy.visit('/universes/public-test-universe/items/test-event/edit');
+  it('deletes the event and sees that it is removed from the timeline that imported it as well', () => {
+    cy.visit('/universes/public-test-universe/items/test-event/edit');
 
-  //   cy.get('.tabs-buttons').contains('Timeline').click();
-  //   cy.get('input').filter((k, el) => el.value === 'Cypress Event').siblings('button').contains('Remove').click();
-  //   cy.get('#save-btn').click();
+    cy.get('.tabs-buttons').contains('Timeline').click();
+    cy.get('input').filter((k, el) => el.value === 'Cypress Event').siblings('button').contains('Remove').click();
+    cy.get('#save-btn').click();
 
-  //   cy.visit('/universes/public-test-universe/items/test-timeline?tab=timeline');
-  //   cy.get('.timeline>.flex-col').children().should('have.length', timelineEvents);
-  //   cy.get('.timeline>.flex-col>div').first().should('not.contain', 'January 1st 2007, 0:00 — Cypress Event of Test Event');
-  // });
+    cy.visit('/universes/public-test-universe/items/test-timeline?tab=timeline');
+    cy.get('.timeline>.flex-col').children().should('have.length', timelineEvents);
+    cy.get('.timeline>.flex-col>div').first().should('not.contain', 'January 1st 2007, 0:00 — Cypress Event of Test Event');
+  });
 
   it('goes to create a new item, sees that the correct type is preselected', () => {
     cy.visit('/universes/public-test-universe');

--- a/cypress/e2e/note_spec.cy.js
+++ b/cypress/e2e/note_spec.cy.js
@@ -91,4 +91,38 @@ describe('Note spec', () => {
     cy.visit('/universes/public-test-universe/items/test-article');
     cy.get('#tabBtns [data-tab=notes]').should('not.exist');
   });
+
+  it('adds a tag to the note', () => {
+    cy.login('testwriter');
+    cy.visit('/notes');
+    cy.get('#note-list').contains('Public Test Note').click();
+
+    cy.get('#note-control-tabs .edit').click();
+    cy.get('#note_tags').type(' cypress')
+    cy.get('#save').click();
+
+    cy.get('#note-controls .preview .tags').should('contain', '#cypress');
+  });
+
+  it('tries filtering notes by the tag', () => {
+    cy.login('testwriter');
+    cy.visit('/notes');
+    cy.get('#note-list .tags a').contains('cypress').click();
+
+    cy.get('#note-list').children().filter(':visible').should('have.length', 1);
+    cy.get('#note-list').get('h2').filter(':visible').should('have.text', 'Public Test Note');
+  });
+
+  it('removes the tag from the note', () => {
+    cy.login('testwriter');
+    cy.visit('/notes');
+    cy.get('#note-list').contains('Public Test Note').click();
+
+    cy.get('#note-control-tabs .edit').click();
+    cy.get('#note_tags').clear();
+    cy.get('#note_tags').type('{ctrl}a{backspace}test public');
+    cy.get('#save').click();
+
+    cy.get('#note-controls .preview .tags').should('not.contain', '#cypress');
+  });
 });

--- a/cypress/e2e/note_spec.cy.js
+++ b/cypress/e2e/note_spec.cy.js
@@ -1,0 +1,94 @@
+describe('Note spec', () => {
+  it('visits item, sees that notes tab is disabled and enables it', () => {
+    cy.logout();
+
+    cy.visit('/universes/public-test-universe/items/test-article');
+    cy.get('#tabBtns [data-tab=notes]').should('not.exist');
+
+    cy.login('testadmin');
+
+    cy.visit('/universes/public-test-universe/items/test-article');
+    cy.get('#tabBtns [data-tab=notes]').should('have.text', 'Notes (Hidden)');
+    cy.get('#action-bar').contains('Edit').click();
+
+    cy.get('#edit #notes').parent().click();
+    cy.get('#preview-btn').click();
+  });
+
+  it('note author visits item, sees both item notes', () => {
+    cy.login('testwriter');
+    cy.visit('/universes/public-test-universe/items/test-article?tab=notes');
+    cy.get('#note-list').children().should('have.length', 2);
+  });
+
+  it('note author visits notes page, sees all four notes', () => {
+    cy.login('testwriter');
+    cy.visit('/notes');
+    cy.get('#note-list').children().should('have.length', 4);
+  });
+
+  it('other user visits item, sees only the public note', () => {
+    cy.login('testreader');
+    cy.visit('/universes/public-test-universe/items/test-article?tab=notes');
+    cy.get('#note-list').children().should('have.length', 1);
+    cy.get('#note-list').get('h2').should('have.text', 'Public Article Note');
+  });
+
+  it('other user visits notes page, sees no notes', () => {
+    cy.login('testreader');
+    cy.visit('/notes');
+    cy.get('#note-list').children().should('have.length', 0);
+  });
+
+  it('links note to an item, sees the note on that item\'s notes page', () => {
+    cy.login('testwriter');
+    cy.visit('/notes');
+    cy.get('#note-list').contains('Public Test Note').click();
+
+    cy.get('#note-control-tabs .edit').click();
+    cy.get('#note-items input').first().type('Test Character');
+    cy.get('.options-container .option').filter(':visible').click();
+    cy.get('#save').click();
+
+    cy.get('#note-items-list').children().should('have.length', 1);
+    cy.get('#note-items-list').contains('Test Character').click();
+
+    cy.get('#tabBtns').contains('Notes (Hidden)').click();
+    cy.get('#note-list').children().should('have.length', 1);
+    cy.get('#note-list').get('h2').should('have.text', 'Public Test Note');
+  });
+
+  it('unlinks the note, no longer sees it on that item\'s notes page', () => {
+    cy.login('testwriter');
+    cy.visit('/notes');
+    cy.get('#note-list').contains('Public Test Note').click();
+
+    cy.get('#note-control-tabs .edit').click();
+    cy.get('#note-items-edit').contains('Test Character').siblings('a').contains('delete').click();
+    cy.get('#save').click();
+
+    cy.get('#note-items-list').children().should('have.length', 0);
+
+    cy.visit('/universes/public-test-universe/items/test-character');
+    cy.get('#tabBtns [data-tab=notes]').should('not.exist');
+  });
+
+  it('disables notes tab again', () => {
+    cy.login('testadmin');
+
+    cy.visit('/universes/public-test-universe/items/test-article');
+    cy.get('#tabBtns [data-tab=notes]').should('have.text', 'Notes');
+    cy.get('#action-bar').contains('Edit').click();
+
+    cy.get('#edit #notes').parent().click();
+    cy.get('#preview-btn').click();
+
+    cy.get('#tabBtns [data-tab=notes]').should('have.text', 'Notes (Hidden)');
+    cy.get('#action-bar').contains('Edit').click();
+
+    cy.logout();
+
+    cy.visit('/universes/public-test-universe/items/test-article');
+    cy.get('#tabBtns [data-tab=notes]').should('not.exist');
+  });
+});

--- a/db/generate/defaults.js
+++ b/db/generate/defaults.js
@@ -41,9 +41,7 @@ module.exports.defaultItemData = {
         { title: null, time: Math.round(Math.random() * 31557600000), imported: false },
       ],
     },
-    comments: {
-      title: 'Comments',
-    },
+    comments: true,
   },
   timeline(items) {
     const imports = items.reduce((list, item) => ([

--- a/db/generate/index.js
+++ b/db/generate/index.js
@@ -53,8 +53,8 @@ async function postComment(poster, thread, comment) {
   await api.discussion.postCommentToThread(poster, thread.id, { body: comment });
 }
 
-async function createNote(owner, title, body, public, items=[], boards=[]) {
-  const [,, uuid] = await api.note.post(owner, { title, body, public });
+async function createNote(owner, title, body, public, tags, items=[], boards=[]) {
+  const [,, uuid] = await api.note.post(owner, { title, body, public, tags });
   const [, note] = await api.note.getOne(owner, uuid);
   for (const item of items) {
     await api.note.linkToItem(owner, item.universe_short, item.shortname, uuid);
@@ -137,10 +137,10 @@ async function main() {
   await postComment(users.testwriter, chatroomThread, '# Markdown test\n- **bold**\n- *italics*\n- etc.');
 
   console.log('Creating notes...');
-  await createNote(users.testwriter, 'Public Test Note', loremIpsum, true);
-  await createNote(users.testwriter, 'Public Article Note', loremIpsum, true, [testArticle]);
-  await createNote(users.testwriter, 'Private Test Note', loremIpsum, false);
-  await createNote(users.testwriter, 'Private Article Note', loremIpsum, false, [testArticle]);
+  await createNote(users.testwriter, 'Public Test Note', loremIpsum, true, ['test', 'public']);
+  await createNote(users.testwriter, 'Public Article Note', loremIpsum, true, ['article', 'public'], [testArticle]);
+  await createNote(users.testwriter, 'Private Test Note', loremIpsum, false, ['test', 'private']);
+  await createNote(users.testwriter, 'Private Article Note', loremIpsum, false, ['article', 'private'], [testArticle]);
 
   schemaConn.end();
   db.end();

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -230,6 +230,13 @@ CREATE TABLE tag (
   FOREIGN KEY (item_id) REFERENCES item (id)
 );
 
+CREATE TABLE notetag (
+  note_id INT NOT NULL,
+  tag VARCHAR(32),
+  UNIQUE(note_id, tag),
+  FOREIGN KEY (note_id) REFERENCES note (id)
+);
+
 CREATE TABLE sentemail (
   recipient VARCHAR(64) NOT NULL,
   topic VARCHAR(64) NOT NULL,

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -91,11 +91,29 @@ CREATE TABLE threadcomment (
 
 CREATE TABLE note (
   id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  uuid VARCHAR(36) UNIQUE,
+  title VARCHAR(64),
   body VARCHAR(2048) NOT NULL,
+  public BOOLEAN,
   author_id INT NOT NULL,
   created_at TIMESTAMP NOT NULL,
   updated_at TIMESTAMP NOT NULL,
   FOREIGN KEY (author_id) REFERENCES user (id)
+);
+
+CREATE TABLE noteboard (
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(64) NOT NULL,
+  shortname VARCHAR(64) UNIQUE NOT NULL,
+  universe_id INT NOT NULL,
+  FOREIGN KEY (universe_id) REFERENCES universe (id)
+);
+
+CREATE TABLE boardnote (
+  note_id INT NOT NULL,
+  board_id INT NOT NULL,
+  FOREIGN KEY (note_id) REFERENCES note (id),
+  FOREIGN KEY (board_id) REFERENCES noteboard (id)
 );
 
 CREATE TABLE item (

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -93,7 +93,7 @@ CREATE TABLE note (
   id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   uuid VARCHAR(36) UNIQUE,
   title VARCHAR(64),
-  body VARCHAR(2048) NOT NULL,
+  body TEXT NOT NULL,
   public BOOLEAN,
   author_id INT NOT NULL,
   created_at TIMESTAMP NOT NULL,
@@ -105,6 +105,7 @@ CREATE TABLE noteboard (
   id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   title VARCHAR(64) NOT NULL,
   shortname VARCHAR(64) UNIQUE NOT NULL,
+  public BOOLEAN,
   universe_id INT NOT NULL,
   FOREIGN KEY (universe_id) REFERENCES universe (id)
 );

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -89,6 +89,15 @@ CREATE TABLE threadcomment (
   FOREIGN KEY (comment_id) REFERENCES comment (id)
 );
 
+CREATE TABLE note (
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  body VARCHAR(2048) NOT NULL,
+  author_id INT NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  FOREIGN KEY (author_id) REFERENCES user (id)
+);
+
 CREATE TABLE item (
   id INT NOT NULL AUTO_INCREMENT,
   title VARCHAR(64) NOT NULL,
@@ -114,6 +123,13 @@ CREATE TABLE itemcomment (
   comment_id INT NOT NULL,
   FOREIGN KEY (item_id) REFERENCES item (id),
   FOREIGN KEY (comment_id) REFERENCES comment (id)
+);
+
+CREATE TABLE itemnote (
+  item_id INT NOT NULL,
+  note_id INT NOT NULL,
+  FOREIGN KEY (item_id) REFERENCES item (id),
+  FOREIGN KEY (note_id) REFERENCES note (id)
 );
 
 CREATE TABLE itemimage (

--- a/index.js
+++ b/index.js
@@ -178,6 +178,6 @@ app.use((err, req, res, next) => {
   next();
 });
 
-app.listen(PORT, '0.0.0.0', () => {
+app.listen(PORT, () => {
   logger.info(`Example app listening at http://localhost:${PORT}`);
 });

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -435,21 +435,9 @@ button:disabled {
  
 .inputGroup {
   display: grid;
-  gap:  0.5rem;
-  grid-template-columns: 1fr 2fr 3fr;
-}
-
-.inputGroup label {
-  grid-row: 1 / 1;
-  grid-column: 1 / 1;
-  align-self: center;
-}
-
-.inputGroup input,
-.inputGroup textarea,
-.inputGroup select {
-  grid-row: 1 / 1;
-  grid-column: 2 / 2;
+  align-items: center;
+  grid-template-columns: 2fr 3fr 4fr;
+  gap: 0.5rem;
 }
 
 @media only screen and (max-device-width: 480px) {
@@ -779,6 +767,60 @@ header .badge {
 
 .options-container div:hover {
   background-color: #f1f1f1;
+}
+
+/* Slider Switches */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 48px;
+  height: 24px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  -webkit-transition: .4s;
+  transition: .4s;
+  border-radius: 24px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  background-color: #2196F3;
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
 }
 
 /* Generic classes */

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -312,6 +312,21 @@ header {
   }
 }
 
+.modal {
+  display: flex;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 15;
+  background-color: #0007;
+  margin: 0;
+  max-width: 100vw;
+  justify-content: center;
+  align-items: center;
+}
+
 .timeline {
   display: flex;
 }
@@ -348,21 +363,6 @@ header {
   border-radius: 0.25rem;
 }
 
-.modal {
-  display: flex;
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 15;
-  background-color: #0007;
-  margin: 0;
-  max-width: 100vw;
-  justify-content: center;
-  align-items: center;
-}
-
 .gallery .itemKey.modal img {
   max-height: calc(95vh - 1rem);
   max-width: 95vw;
@@ -370,6 +370,12 @@ header {
 
 .gallery .itemKey.modal .label {
   margin-top: 0.5rem;
+}
+
+.notes {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1rem;
 }
 
 table {
@@ -623,6 +629,7 @@ h4, h5 {
 
 /* Fancy Links */
 .link {
+  display: inline;
   position: relative;
   text-decoration: none;
   border: none;

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -1032,6 +1032,9 @@ input:checked + .slider:before {
   padding: 0.5rem;
 }
 
+.w-50 {
+  width: 50%;
+}
 .w-100 {
   width: 100%;
 }

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -378,6 +378,12 @@ header {
   gap: 0.25rem 1rem;
 }
 
+@media only screen and (max-device-width: 480px) {
+  .notes {
+    grid-template-columns: 1fr;
+  }
+}
+
 table {
   border-collapse: collapse;
   border-radius: 0.25rem;
@@ -767,12 +773,19 @@ header .badge {
   box-sizing: border-box;
 }
 
-.options-container div {
+.options-container .option-group-heading {
+  padding: 0.125rem;
+  position: sticky;
+  top: 0;
+  background-color: #fff;
+}
+
+.options-container .option {
   padding: 0.25rem;
   cursor: pointer;
 }
 
-.options-container div:hover {
+.options-container .option:hover {
   background-color: #f1f1f1;
 }
 
@@ -828,6 +841,32 @@ input:checked + .slider:before {
   -webkit-transform: translateX(24px);
   -ms-transform: translateX(24px);
   transform: translateX(24px);
+}
+
+@media only screen and (max-device-width: 480px) {
+  .switch {
+    width: 96px;
+    height: 48px;
+  }
+  
+  .slider {
+    border-radius: 48px;
+  }
+  
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: 36px;
+    width: 36px;
+    left: 6px;
+    bottom: 6px;
+  }
+  
+  input:checked + .slider:before {
+    -webkit-transform: translateX(48px);
+    -ms-transform: translateX(48px);
+    transform: translateX(48px);
+  }
 }
 
 /* Generic classes */

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -375,7 +375,7 @@ header {
 .notes {
   display: grid;
   grid-template-columns: 2fr 1fr;
-  gap: 1rem;
+  gap: 0.25rem 1rem;
 }
 
 table {
@@ -988,6 +988,9 @@ input:checked + .slider:before {
 }
 .pa-1 {
   padding: 0.25rem;
+}
+.pa-2 {
+  padding: 0.5rem;
 }
 
 .w-100 {

--- a/static/scripts/easyMDE.js
+++ b/static/scripts/easyMDE.js
@@ -9,6 +9,7 @@ function setupEasyMDE(selector, renderContext = {}, extraSettings = {}) {
       unorderedListStyle: '-',
       sideBySideFullscreen: true,
       autoRefresh: { delay: 300 },
+      spellChecker: false,
       previewRender: (plainText, preview) => {
         renderMarkdown(universe, plainText, context).then((html) => {
             preview.innerHTML = html;

--- a/static/scripts/itemEditor.js
+++ b/static/scripts/itemEditor.js
@@ -473,7 +473,7 @@ async function resetTabs(toSelect=null) {
   document.querySelector('#body').dataset.tab = bodyTabName;
   let firstTab = ('body' in obj_data) ? bodyTabName : null;
   if ('body' in obj_data) await addTab('body', bodyTabName, true);
-  for (const type of ['lineage', 'location', 'timeline', 'gallery', 'comments']) {
+  for (const type of ['lineage', 'location', 'timeline', 'gallery']) {
     if (type in obj_data) {
       if (Object.keys(obj_data[type]).length === 0) {
         const newState = { ...obj_data };

--- a/static/scripts/markdown/render.js
+++ b/static/scripts/markdown/render.js
@@ -56,12 +56,12 @@ class MarkdownElement {
   }
 }
 
-function loadMarkdown(container, universeShortname, body, ctx, frmt) {
-  parseMarkdown(body).evaluate(universeShortname, ctx, frmt).then(data => {
-    container.classList.add('markdown');
-    const nodes = new MarkdownElement({ getElement: () => container }, data);
-    nodes.render();
-  });
+async function loadMarkdown(container, universeShortname, body, ctx, frmt) {
+  const data = await parseMarkdown(body).evaluate(universeShortname, ctx, frmt);
+  container.classList.add('markdown');
+  const nodes = new MarkdownElement({ getElement: () => container }, data);
+  nodes.render();
+  return nodes;
 }
 
 async function renderMarkdown(universeShortname, body, ctx, frmt) {

--- a/static/scripts/markdown/render.js
+++ b/static/scripts/markdown/render.js
@@ -56,18 +56,22 @@ class MarkdownElement {
   }
 }
 
-async function loadMarkdown(container, universeShortname, body, ctx, frmt) {
+async function loadMarkdown(container, universeShortname, body, ctx, frmt, render=true) {
   const data = await parseMarkdown(body).evaluate(universeShortname, ctx, frmt);
   container.classList.add('markdown');
   const nodes = new MarkdownElement({ getElement: () => container }, data);
-  nodes.render();
+  if (render) nodes.render();
   return nodes;
 }
 
 async function renderMarkdown(universeShortname, body, ctx, frmt) {
-  const data = await parseMarkdown(body).evaluate(universeShortname, ctx, frmt);
   const container = createElement('div');
-  const nodes = new MarkdownElement({ getElement: () => container }, data);
-  nodes.render();
+  await loadMarkdown(container, universeShortname, body, ctx, frmt);
   return container.innerHTML;
+}
+
+async function renderMdPreview(universeShortname, body, ctx, frmt) {
+  const container = createElement('div');
+  const nodes = await loadMarkdown(container, universeShortname, body, ctx, frmt);
+  return nodes.children.map(child => child.getElement().textContent).join(' ');
 }

--- a/static/scripts/searchableSelect.js
+++ b/static/scripts/searchableSelect.js
@@ -1,24 +1,37 @@
-function createSearchableSelect(id, options, onchange) {
+function createSearchableSelect(id, options, onchange, groups={}) {
   const input = createElement('input');
   const valueInput = createElement('input', { attrs: { id, hidden: true } });
-  const optionsContainer = createElement('div', { classList: ['options-container'], children: [
-    ...Object.keys(options).map(option => (
-      createElement('div', { attrs: { value: option, innerText: options[option] } })
-    )),
-  ] });
+  const optionsContainer = createElement('div', { classList: ['options-container'] });
   const select = createElement('div', { classList: ['searchable-select'], children: [
     input,
     valueInput,
     optionsContainer,
   ] });
 
-  select.setOptions = (options) => {
+  select.setOptions = (options, groups={}) => {
     optionsContainer.innerHTML = '';
+    const groupOptions = {};
     for (const key in options) {
-      optionsContainer.appendChild(createElement('div', { attrs: { value: key, innerText: options[key] } }));
+      const option = createElement('div', { classList: ['option'], attrs: { value: key, innerText: options[key] } });
+      if (groups[key]) {
+        if (!(groups[key] in groupOptions)) {
+          groupOptions[groups[key]] = createElement('div');
+          groupOptions[groups[key]].appendChild(createElement('div', { classList: ['option-group-heading'], children: [
+            createElement('b', { attrs: { innerText: groups[key] } })
+          ] }));
+        }
+        groupOptions[groups[key]].appendChild(option);
+      } else {
+        optionsContainer.appendChild(option);
+      }
+    }
+    for (const group in groupOptions) {
+      optionsContainer.appendChild(groupOptions[group]);
     }
     setupListeners();
   };
+
+  select.setOptions(options, groups);
 
   input.addEventListener('input', function() {
     valueInput.value = '';
@@ -44,7 +57,7 @@ function createSearchableSelect(id, options, onchange) {
   });
 
   function setupListeners() {
-    optionsContainer.querySelectorAll('div').forEach(function(option) {
+    optionsContainer.querySelectorAll('.option').forEach(function(option) {
       option.addEventListener('click', function() {
         valueInput.value = this.value;
         if (onchange) onchange(this.value);
@@ -53,7 +66,6 @@ function createSearchableSelect(id, options, onchange) {
       });
     });
   }
-  setupListeners();
   
   return select;
 }

--- a/templates/components/comments.pug
+++ b/templates/components/comments.pug
@@ -33,3 +33,7 @@ div
         el.form.post.disabled = el.value.length > 2000;
       };
     });
+      
+    document.querySelectorAll('.comment').forEach((el) => {
+      loadMarkdown(el, '#{universe.shortname}', el.dataset.val, null);
+    });

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -249,7 +249,7 @@ block append styles
           addLinkedItem(itemShort, item, uniShort, uni);
         }
         updateTitle(title);
-        if (author_id === #{contextUser.id}) controlTabs.classList.remove('hidden');
+        if (#{contextUser ? `author_id === ${contextUser.id}` : 'false'}) controlTabs.classList.remove('hidden');
         noteState = 'edit';
         leftBtn.classList.remove('hidden');
 

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -21,7 +21,7 @@
             |  — 
             b Updated: 
             | #{formatDate(note.updated_at)}
-          small.body( data-val=note.body )
+          small.body
     #note-edit.hidden
       textarea
     #note-display.sheet.hidden
@@ -133,11 +133,12 @@
         window.history.pushState({ path: newurl }, '', newurl);
 
         const noteCard = noteList.querySelector(`[data-uuid="${uuid}"]`);
-        const { title, public, body } = noteCard && JSON.parse(noteCard.dataset.note);
+        const { title, public, body, author_id } = noteCard && JSON.parse(noteCard.dataset.note);
         easyMDE.value(body);
         editForm.note_title.value = title;
         editForm.note_public.checked = public;
         updateTitle(title);
+        if (author_id !== #{contextUser.id}) controlTabs.classList.add('hidden');
 
         previewNote();
       }
@@ -198,11 +199,12 @@
       }
 
         
-      document.querySelectorAll('#note-list .body').forEach(async (el) => {
+      document.querySelectorAll('#note-list .card').forEach(async (el) => {
+        const body = el.querySelector('.body');
         const tmp = createElement('div');
-        await loadMarkdown(tmp, '#{universe && universe.shortname}', el.dataset.val, null);
+        await loadMarkdown(tmp, '#{universe && universe.shortname}', JSON.parse(el.dataset.note).body, null);
         const text = tmp.textContent;
         const maxLength = 100;
-        el.textContent = text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
+        body.textContent = text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
       });
     })();

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -258,6 +258,8 @@ block append styles
 
       let linkedItemCounter = 0;
       function addLinkedItem(shortname, title, universe_short, universe) {
+        const exists = noteItemsList.querySelectorAll(`li[data-item=${shortname}]`).length > 0;
+        if (exists) return;
         const i = linkedItemCounter++;
         noteItemsList.appendChild(createElement('li', { classList: ['d-flex', 'align-center'], dataset: {item: shortname}, children: [
           createElement('a', { attrs: {

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -83,6 +83,14 @@ block append styles
             input( id='note_public' name='note_public' type='checkbox' )
             span.slider
         
+        label Linked items:
+        ul#note-items-list.ma-0.pa-0
+        #note-items
+
+        label Pinned boards:
+        ul#note-boards-list.ma-0.pa-0
+        #note-boards
+        
         input.hidden( id='create' type='submit' value='Create' formaction=`${ADDR_PREFIX}/notes/create` )
         input.hidden( id='save' type='submit' value='Save' formaction=`${ADDR_PREFIX}/notes/edit` )
         
@@ -91,6 +99,15 @@ block append styles
         input( id='note_universe' type='hidden' name='note_universe' value=(universe && universe.shortname) )
         input( id='note_item' type='hidden' name='note_item' value=(item && item.shortname) )
         input( id='note_board' type='hidden' name='note_board' value=(board && board.shortname) )
+      
+      .preview.hidden
+        h3 Linked items:
+        ul#note-items-list.ma-0
+        #note-items
+
+        h3 Pinned boards:
+        ul#note-boards-list.ma-0
+        #note-boards
 
 
   script.
@@ -100,6 +117,7 @@ block append styles
       if (!window.setupEasyMDE) throw 'easyMDE.js not loaded!';
       if (!window.parseMarkdown) throw 'markdown/parse.js not loaded!';
       if (!window.loadMarkdown) throw 'markdown/render.js not loaded!';
+      if (!window.createSearchableSelect) throw 'searchableSelect not loaded!';
 
       let noteState = 'list';
       const leftBtn = document.querySelector('#notes-left-btn');
@@ -110,6 +128,14 @@ block append styles
 
       const noteControls = document.querySelector('#note-controls');
       const editForm = noteControls.querySelector('.edit');
+      const previewPanel = noteControls.querySelector('.preview');
+      const noteItems = document.querySelector('#note-items');
+      const noteBoards = document.querySelector('#note-boards');
+      const noteItemsList = document.querySelector('.edit #note-items-list');
+      const noteBoardsList = document.querySelector('.edit #note-boards-list');
+      const noteItemsPreviewList = document.querySelector('.preview #note-items-list');
+      const noteBoardsPreviewList = document.querySelector('.preview #note-boards-list');
+      const itemsAndBoards = {};
 
       const controlTabs = document.querySelector('#note-control-tabs');
       const editTab = controlTabs.querySelector('.edit');
@@ -148,6 +174,7 @@ block append styles
         noteDisplay.classList.add('hidden');
         noteEdit.classList.remove('hidden');
         editForm.classList.remove('hidden');
+        previewPanel.classList.add('hidden');
       }
 
       function previewNote() {
@@ -157,6 +184,7 @@ block append styles
         noteDisplay.classList.remove('hidden');
         noteEdit.classList.add('hidden');
         editForm.classList.add('hidden');
+        previewPanel.classList.remove('hidden');
       }
 
       function loadingNote() {
@@ -165,6 +193,7 @@ block append styles
         noteDisplay.classList.add('hidden');
         noteEdit.classList.add('hidden');
         editForm.classList.add('hidden');
+        previewPanel.classList.add('hidden');
       }
 
       async function openNote(uuid) {
@@ -187,15 +216,61 @@ block append styles
         loadingNote();
         const [, note] = await getJSON(`#{noteBaseRoute}/${uuid}`);
         const { title, public, body, author_id, items, boards } = note;
+        console.log(items, boards)
         easyMDE.value(body);
         editForm.note_title.value = title;
         editForm.note_public.checked = public;
+        if (!itemsAndBoards.items) {
+          const [, items] = await getJSON(`#{ADDR_PREFIX}/api/writable-items`);
+          itemsAndBoards.items = {};
+          itemsAndBoards.itemOptions = {};
+          itemsAndBoards.itemGroups = {};
+          for (const item of items) {
+            const key = `${item.universe_short}/${item.shortname}`;
+            itemsAndBoards.items[key] = item;
+            itemsAndBoards.itemOptions[key] = item.title;
+            itemsAndBoards.itemGroups[key] = item.universe;
+          }
+          noteItems.innerHTML = '';
+          noteItems.appendChild(createSearchableSelect(
+            'note-items-select',
+            itemsAndBoards.itemOptions,
+            (value) => {
+              const item = itemsAndBoards.items[value];
+              addLinkedItem(item.shortname, item.title, item.universe_short, item.universe);
+            },
+            itemsAndBoards.itemGroups,
+          ));
+        }
+        for (const [item, itemShort, uni, uniShort] of items) {
+          addLinkedItem(itemShort, item, uniShort, uni);
+        }
         updateTitle(title);
         if (author_id === #{contextUser.id}) controlTabs.classList.remove('hidden');
         noteState = 'edit';
         leftBtn.classList.remove('hidden');
 
         previewNote();
+      }
+
+      let linkedItemCounter = 0;
+      function addLinkedItem(shortname, title, universe_short, universe) {
+        const i = linkedItemCounter++;
+        noteItemsList.appendChild(createElement('li', { classList: ['d-flex', 'align-center'], dataset: {item: shortname}, children: [
+          createElement('a', { attrs: {
+            innerText: 'delete',
+            onclick: () => noteItemsList.querySelector(`li[data-item=${shortname}]`).remove(),
+          }, classList: ['material-symbols-outlined', 'link'] }),
+          createElement('span', { attrs: { innerText: title } }),
+          createElement('input', { attrs: { type: 'hidden', name: `items[${i}][item]`, value: shortname } }),
+          createElement('input', { attrs: { type: 'hidden', name: `items[${i}][universe]`, value: universe_short } }),
+        ] }));
+        noteItemsPreviewList.appendChild(createElement('li', { classList: ['d-flex', 'align-center'], dataset: {item: shortname}, children: [
+          createElement('a', { attrs: {
+            innerText: title,
+            href: `#{ADDR_PREFIX}/universes/${universe_short}/items/${shortname}`,
+          }, classList: ['link', 'link-animated'] }),
+        ] }));
       }
 
       function createNote() {
@@ -222,9 +297,13 @@ block append styles
         noteEdit.classList.add('hidden');
         noteDisplay.classList.add('hidden');
         editForm.classList.add('hidden');
+        previewPanel.classList.add('hidden');
         controlTabs.classList.add('hidden');
         editTab.classList.remove('selected');
         leftBtn.innerText = 'Create Note';
+
+        noteItemsList.innerHTML = '';
+        noteItemsPreviewList.innerHTML = '';
 
         const query = new URLSearchParams(window.location.search);
         query.delete('note');

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -62,6 +62,11 @@ block append styles
             b Updated: 
             | #{formatDate(note.updated_at)}
           small.body
+          if note.tags
+            small.d-flex.flex-wrap.gap-1.tags
+              each noteTag in note.tags
+                if noteTag
+                  a.link.link-animated( data-tag=noteTag ) ##{noteTag}
     #note-edit.hidden
       textarea
     #note-display.sheet.hidden
@@ -108,6 +113,8 @@ block append styles
         ul#note-items-list.ma-0
         #note-items
 
+        p.tags
+
         //- h3 Pinned boards:
         //- ul#note-boards-list.ma-0
         //- #note-boards
@@ -144,12 +151,40 @@ block append styles
       const editTab = controlTabs.querySelector('.edit');
       const previewTab = controlTabs.querySelector('.preview');
 
+      const noteCards = noteList.querySelectorAll('.card');
+      const noteTags = {};
+      const tagLinks = {};
+      let currentTagFilter = null;
+      function filterByTag(tag) {
+        if (tag === currentTagFilter) tag = null;
+        currentTagFilter = tag;
+        noteList.querySelectorAll('.card .tags a').forEach(tagLink => tagLink.classList.remove('link-selected'));
+        tagLinks[tag]?.forEach(tagLink => tagLink.classList.add('link-selected'));
+        noteCards.forEach(card => {
+          if (noteTags[card.dataset.uuid][tag] || tag === null) card.classList.remove('hidden');
+          else card.classList.add('hidden');
+        });
+      }
+      noteCards.forEach(card => {
+        noteTags[card.dataset.uuid] = {};
+        card.querySelectorAll('.tags a').forEach(tagLink => {
+          const tag = tagLink.dataset.tag;
+          noteTags[card.dataset.uuid][tag] = true;
+          if (!(tag in tagLinks)) tagLinks[tag] = [];
+          tagLinks[tag].push(tagLink);
+          tagLink.addEventListener('click', e => {
+            e.stopPropagation();
+            filterByTag(tag);
+          });
+        });
+      });
+
       const previewTitle = noteDisplay.querySelector('.title');
       async function updateTitle(title) {
         previewTitle.textContent = title;
       }
-      const previewTags = noteDisplay.querySelector('.tags');
-      async function updateTitle(tags) {
+      const previewTags = previewPanel.querySelector('.tags');
+      async function updateTags(tags) {
         previewTags.textContent = tags.split(' ').map(t => `#${t}`).join(' ');
       }
       const displayNodes = await loadMarkdown(noteDisplay.querySelector('.body'), '#{universe && universe.shortname}', '', null);

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -1,12 +1,148 @@
-block append scripts
-  script.
-    function
-
 .notes
-  .sheet
-  .sheet
-    ul.navbarBtns.flex-col.gap-2
-      li.navbarBtn.big-text
-        h3.link.link-animated.ma-0( onclick='newNote()' ) New Note
-      li.navbarBtn.big-text
-        h3.link.link-animated.ma-0( onclick='listNotes()' ) List Notes
+  p.ma-0.pa-1#notes-left-btn
+    a.link.link-animated Create Note
+
+  div
+    #note-control-tabs.hidden
+      ul.navbarBtns.gap-2
+        li.edit.navbarBtn.grow-1
+          b.navbarBtnLink.navbarText.ma-0.pa-1 Edit
+        li.preview.navbarBtn.grow-1
+          b.navbarBtnLink.navbarText.ma-0.pa-1 Preview
+
+  div
+    #note-list.card-list
+      each note in notes
+        .card.sheet
+          | #{JSON.stringify(note)}
+    #note-edit.hidden
+      textarea
+    #note-display.sheet.hidden
+      .title
+      hr
+      .body
+
+  div
+    #note-controls.sheet( style={ position: 'sticky', top: '4rem' } )
+      form.edit.hidden( method='POST' )
+        .grid.align-baseline.gap-2( style={ 'grid-template-columns': 'auto auto' } )
+          label( for='note_title' ) Title:
+          input( id='note_title' type='text' name='note_title' )
+
+          label( for='note_public' ) Public:
+          label.switch
+            input( id='note_public' name='note_public' type='checkbox' )
+            span.slider
+        
+        input.hidden( id='create' type='submit' value='Create' formaction=`${ADDR_PREFIX}/notes/create` )
+        input.hidden( id='save' type='submit' value='Save' formaction=`` )
+        
+        input( id='note_body' type='hidden' name='note_body' )
+        input( id='note_universe' type='hidden' name='note_universe' value=(universe && universe.shortname) )
+        input( id='note_item' type='hidden' name='note_item' value=(item && item.shortname) )
+        input( id='note_board' type='hidden' name='note_board' value=(board && board.shortname) )
+
+
+  script.
+    (async function() {
+      if (!window.createElement) throw 'domUtils not loaded!';
+      if (!window.createSearchableSelect) throw 'searchableSelect not loaded!';
+      if (!window.modal) throw 'modal not loaded!';
+      if (!window.getJSON) throw 'fetchUtils.js not loaded!';
+      if (!window.setupEasyMDE) throw 'easyMDE.js not loaded!';
+      if (!window.parseMarkdown) throw 'markdown/parse.js not loaded!';
+      if (!window.loadMarkdown) throw 'markdown/render.js not loaded!';
+
+      let noteState = 'list';
+      const leftBtn = document.querySelector('#notes-left-btn');
+      const noteList = document.querySelector('#note-list');
+      const noteEdit = document.querySelector('#note-edit');
+      const noteDisplay = document.querySelector('#note-display');
+
+      const noteControls = document.querySelector('#note-controls');
+      const editControls = noteControls.querySelector('.edit');
+
+      const controlTabs = document.querySelector('#note-control-tabs');
+      const editTab = controlTabs.querySelector('.edit');
+      const previewTab = controlTabs.querySelector('.preview');
+
+      const titleNodes = await loadMarkdown(noteDisplay.querySelector('.title'), '#{universe && universe.shortname}', '', null);
+      async function updateTitle(markdown) {
+        const data = await parseMarkdown(markdown).evaluate('#{universe && universe.shortname}', null, (tag) => {
+          if (tag.type === 'p') tag.type = 'h1';
+        });
+        titleNodes.update(data);
+        titleNodes.render();
+      }
+      const displayNodes = await loadMarkdown(noteDisplay.querySelector('.body'), '#{universe && universe.shortname}', '', null);
+      async function updateDisplay(markdown) {
+        const data = await parseMarkdown(markdown).evaluate('#{universe.shortname}', null);
+        displayNodes.update(data);
+        displayNodes.render();
+      }
+      editControls.note_title.addEventListener('change', () => {
+        updateTitle(editControls.note_title.value);
+      });
+      const easyMDE = setupEasyMDE('#note-edit textarea', {universe, context: { item }});
+      easyMDE.codemirror.on('change', () => {
+        updateDisplay(easyMDE.value());
+        editControls.note_body.value = easyMDE.value();
+      });
+
+      function showNoteEditControls() {
+        noteList.classList.add('hidden');
+        noteDisplay.classList.add('hidden');
+        noteEdit.classList.remove('hidden');
+        editControls.classList.remove('hidden');
+        controlTabs.classList.remove('hidden');
+        editTab.classList.add('selected');
+        leftBtn.firstChild.innerText = 'Back to List';
+      }
+      function editNote() {
+        noteState = 'edit';
+        showNoteEditControls();
+        editControls.create.classList.add('hidden');
+        editControls.save.classList.remove('hidden');
+      }
+      function createNote() {
+        noteState = 'new';
+        showNoteEditControls();
+        editControls.create.classList.remove('hidden');
+        editControls.save.classList.add('hidden');
+      }
+      function backToList() {
+        if (noteState === 'new' || noteState === 'edit-unsaved') {
+          if (!confirm('You have unsaved changes! Are you sure you want to go back?')) return;
+        }
+        noteState = 'list';
+        noteList.classList.remove('hidden');
+        noteEdit.classList.add('hidden');
+        editControls.classList.add('hidden');
+        controlTabs.classList.add('hidden');
+        editTab.classList.remove('selected');
+        leftBtn.firstChild.innerText = 'Create Note';
+      }
+
+      leftBtn.addEventListener('click', () => {
+        if (noteState === 'list') createNote();
+        else backToList();
+      });
+
+      editTab.addEventListener('click', () => {
+        controlTabs.querySelectorAll('li').forEach(el => el.classList.remove('selected'));
+        editTab.classList.add('selected');
+        noteDisplay.classList.add('hidden');
+        noteEdit.classList.remove('hidden');
+      });
+
+      previewTab.addEventListener('click', () => {
+        controlTabs.querySelectorAll('li').forEach(el => el.classList.remove('selected'));
+        previewTab.classList.add('selected');
+        noteDisplay.classList.remove('hidden');
+        noteEdit.classList.add('hidden');
+      });
+        
+      document.querySelectorAll('.note').forEach((el) => {
+        loadMarkdown(el, '#{universe.shortname}', el.dataset.val, null);
+      });
+    })();

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -159,6 +159,7 @@ block append styles
         updateDisplay(easyMDE.value());
         editForm.note_body.value = easyMDE.value();
       });
+      let editorNeedsRefresh = false;
 
 
       function showNoteEditControls() {
@@ -175,6 +176,7 @@ block append styles
         noteEdit.classList.remove('hidden');
         editForm.classList.remove('hidden');
         previewPanel.classList.add('hidden');
+        if (editorNeedsRefresh) easyMDE.codemirror.refresh();
       }
 
       function previewNote() {
@@ -218,6 +220,7 @@ block append styles
         const { title, public, body, author_id, items, boards } = note;
         console.log(items, boards)
         easyMDE.value(body);
+        editorNeedsRefresh = true;
         editForm.note_title.value = title;
         editForm.note_public.checked = public;
         if (!itemsAndBoards.items) {

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -164,6 +164,13 @@ block append styles
           if (noteTags[card.dataset.uuid][tag] || tag === null) card.classList.remove('hidden');
           else card.classList.add('hidden');
         });
+
+        const query = new URLSearchParams(window.location.search);
+        if (tag) query.set('note_tag', tag);
+        else query.delete('note_tag');
+        const { protocol, host, pathname, hash } = window.location;
+        const newurl = `${protocol}//${host}${pathname}?${query.toString()}${hash}`;
+        window.history.pushState({ path: newurl }, '', newurl);
       }
       noteCards.forEach(card => {
         noteTags[card.dataset.uuid] = {};
@@ -384,6 +391,10 @@ block append styles
       const uuid = query.get('note');
       if (uuid) {
         openNote(uuid);
+      }
+      const tag = query.get('note_tag');
+      if (tag) {
+        filterByTag(tag);
       }
 
         

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -87,9 +87,9 @@ block append styles
         ul#note-items-edit.ma-0.pa-0
         #note-items
 
-        label Pinned boards:
-        ul#note-boards-edit.ma-0.pa-0
-        #note-boards
+        //- label Pinned boards:
+        //- ul#note-boards-edit.ma-0.pa-0
+        //- #note-boards
         
         input.hidden( id='create' type='submit' value='Create' formaction=`${ADDR_PREFIX}/notes/create` )
         input.hidden( id='save' type='submit' value='Save' formaction=`${ADDR_PREFIX}/notes/edit` )
@@ -105,9 +105,9 @@ block append styles
         ul#note-items-list.ma-0
         #note-items
 
-        h3 Pinned boards:
-        ul#note-boards-list.ma-0
-        #note-boards
+        //- h3 Pinned boards:
+        //- ul#note-boards-list.ma-0
+        //- #note-boards
 
 
   script.
@@ -130,11 +130,11 @@ block append styles
       const editForm = noteControls.querySelector('.edit');
       const previewPanel = noteControls.querySelector('.preview');
       const noteItems = document.querySelector('#note-items');
-      const noteBoards = document.querySelector('#note-boards');
+      //- const noteBoards = document.querySelector('#note-boards');
       const noteItemsList = document.querySelector('.edit #note-items-edit');
-      const noteBoardsList = document.querySelector('.edit #note-boards-edit');
+      //- const noteBoardsList = document.querySelector('.edit #note-boards-edit');
       const noteItemsPreviewList = document.querySelector('.preview #note-items-list');
-      const noteBoardsPreviewList = document.querySelector('.preview #note-boards-list');
+      //- const noteBoardsPreviewList = document.querySelector('.preview #note-boards-list');
       const itemsAndBoards = {};
 
       const controlTabs = document.querySelector('#note-control-tabs');
@@ -218,7 +218,6 @@ block append styles
         loadingNote();
         const [, note] = await getJSON(`#{noteBaseRoute}/${uuid}`);
         const { title, public, body, author_id, items, boards } = note;
-        console.log(items, boards)
         easyMDE.value(body);
         editorNeedsRefresh = true;
         editForm.note_title.value = title;

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -84,11 +84,11 @@ block append styles
             span.slider
         
         label Linked items:
-        ul#note-items-list.ma-0.pa-0
+        ul#note-items-edit.ma-0.pa-0
         #note-items
 
         label Pinned boards:
-        ul#note-boards-list.ma-0.pa-0
+        ul#note-boards-edit.ma-0.pa-0
         #note-boards
         
         input.hidden( id='create' type='submit' value='Create' formaction=`${ADDR_PREFIX}/notes/create` )
@@ -131,8 +131,8 @@ block append styles
       const previewPanel = noteControls.querySelector('.preview');
       const noteItems = document.querySelector('#note-items');
       const noteBoards = document.querySelector('#note-boards');
-      const noteItemsList = document.querySelector('.edit #note-items-list');
-      const noteBoardsList = document.querySelector('.edit #note-boards-list');
+      const noteItemsList = document.querySelector('.edit #note-items-edit');
+      const noteBoardsList = document.querySelector('.edit #note-boards-edit');
       const noteItemsPreviewList = document.querySelector('.preview #note-items-list');
       const noteBoardsPreviewList = document.querySelector('.preview #note-boards-list');
       const itemsAndBoards = {};

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -90,6 +90,9 @@ block append styles
         //- label Pinned boards:
         //- ul#note-boards-edit.ma-0.pa-0
         //- #note-boards
+
+        label( for='note_tags' ) Tags: 
+        textarea( id='note_tags' name='note_tags' )
         
         input.hidden( id='create' type='submit' value='Create' formaction=`${ADDR_PREFIX}/notes/create` )
         input.hidden( id='save' type='submit' value='Save' formaction=`${ADDR_PREFIX}/notes/edit` )
@@ -145,6 +148,10 @@ block append styles
       async function updateTitle(title) {
         previewTitle.textContent = title;
       }
+      const previewTags = noteDisplay.querySelector('.tags');
+      async function updateTitle(tags) {
+        previewTags.textContent = tags.split(' ').map(t => `#${t}`).join(' ');
+      }
       const displayNodes = await loadMarkdown(noteDisplay.querySelector('.body'), '#{universe && universe.shortname}', '', null);
       async function updateDisplay(markdown) {
         const data = await parseMarkdown(markdown).evaluate('#{universe && universe.shortname}', null);
@@ -153,6 +160,9 @@ block append styles
       }
       editForm.note_title.addEventListener('change', () => {
         updateTitle(editForm.note_title.value);
+      });
+      editForm.note_tags.addEventListener('change', () => {
+        updateTags(editForm.note_tags.value);
       });
       const easyMDE = setupEasyMDE('#note-edit textarea', { universe: !{JSON.stringify(universe || null)}, context: { item: !{JSON.stringify(item || null)} }});
       easyMDE.codemirror.on('change', () => {
@@ -222,6 +232,7 @@ block append styles
         editorNeedsRefresh = true;
         editForm.note_title.value = title;
         editForm.note_public.checked = public;
+        editForm.note_tags.value = (note.tags || []).join(' ');
         if (!itemsAndBoards.items) {
           const [, items] = await getJSON(`#{ADDR_PREFIX}/api/writable-items`);
           itemsAndBoards.items = {};
@@ -248,6 +259,7 @@ block append styles
           addLinkedItem(itemShort, item, uniShort, uni);
         }
         updateTitle(title);
+        updateTags(editForm.note_tags.value);
         if (#{contextUser ? `author_id === ${contextUser.id}` : 'false'}) controlTabs.classList.remove('hidden');
         noteState = 'edit';
         leftBtn.classList.remove('hidden');
@@ -288,6 +300,7 @@ block append styles
         editForm.note_public.checked = false;
         easyMDE.value('');
         updateTitle('');
+        updateTags('');
       }
 
       function backToList() {

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -13,12 +13,19 @@
   div
     #note-list.card-list
       each note in notes
-        .card.sheet
-          | #{JSON.stringify(note)}
+        .sheet.card.d-flex.flex-col.gap-1( data-uuid=note.uuid data-note=note )
+          h2.ma-0 #{note.title}
+          span
+            b Author: 
+            a.link.link-animated( href=`/users/${noteAuthors[note.author_id].username}` ) #{noteAuthors[note.author_id].username}
+            |  — 
+            b Updated: 
+            | #{formatDate(note.updated_at)}
+          small.body( data-val=note.body )
     #note-edit.hidden
       textarea
     #note-display.sheet.hidden
-      .title
+      h1.title
       hr
       .body
 
@@ -35,9 +42,10 @@
             span.slider
         
         input.hidden( id='create' type='submit' value='Create' formaction=`${ADDR_PREFIX}/notes/create` )
-        input.hidden( id='save' type='submit' value='Save' formaction=`` )
+        input.hidden( id='save' type='submit' value='Save' formaction=`${ADDR_PREFIX}/notes/edit` )
         
         input( id='note_body' type='hidden' name='note_body' )
+        input( id='note_uuid' type='hidden' name='note_uuid' )
         input( id='note_universe' type='hidden' name='note_universe' value=(universe && universe.shortname) )
         input( id='note_item' type='hidden' name='note_item' value=(item && item.shortname) )
         input( id='note_board' type='hidden' name='note_board' value=(board && board.shortname) )
@@ -60,19 +68,15 @@
       const noteDisplay = document.querySelector('#note-display');
 
       const noteControls = document.querySelector('#note-controls');
-      const editControls = noteControls.querySelector('.edit');
+      const editForm = noteControls.querySelector('.edit');
 
       const controlTabs = document.querySelector('#note-control-tabs');
       const editTab = controlTabs.querySelector('.edit');
       const previewTab = controlTabs.querySelector('.preview');
 
-      const titleNodes = await loadMarkdown(noteDisplay.querySelector('.title'), '#{universe && universe.shortname}', '', null);
-      async function updateTitle(markdown) {
-        const data = await parseMarkdown(markdown).evaluate('#{universe && universe.shortname}', null, (tag) => {
-          if (tag.type === 'p') tag.type = 'h1';
-        });
-        titleNodes.update(data);
-        titleNodes.render();
+      const previewTitle = noteDisplay.querySelector('.title');
+      async function updateTitle(title) {
+        previewTitle.textContent = title;
       }
       const displayNodes = await loadMarkdown(noteDisplay.querySelector('.body'), '#{universe && universe.shortname}', '', null);
       async function updateDisplay(markdown) {
@@ -80,69 +84,125 @@
         displayNodes.update(data);
         displayNodes.render();
       }
-      editControls.note_title.addEventListener('change', () => {
-        updateTitle(editControls.note_title.value);
+      editForm.note_title.addEventListener('change', () => {
+        updateTitle(editForm.note_title.value);
       });
       const easyMDE = setupEasyMDE('#note-edit textarea', {universe, context: { item }});
       easyMDE.codemirror.on('change', () => {
+        const text = easyMDE.value();
+        if (text.length > 2000) easyMDE.value(text.substring(0, 2000));
         updateDisplay(easyMDE.value());
-        editControls.note_body.value = easyMDE.value();
+        editForm.note_body.value = easyMDE.value();
       });
+
 
       function showNoteEditControls() {
         noteList.classList.add('hidden');
-        noteDisplay.classList.add('hidden');
-        noteEdit.classList.remove('hidden');
-        editControls.classList.remove('hidden');
         controlTabs.classList.remove('hidden');
-        editTab.classList.add('selected');
         leftBtn.firstChild.innerText = 'Back to List';
       }
+
       function editNote() {
+        controlTabs.querySelectorAll('li').forEach(el => el.classList.remove('selected'));
+        editTab.classList.add('selected');
+        noteDisplay.classList.add('hidden');
+        noteEdit.classList.remove('hidden');
+        editForm.classList.remove('hidden');
+      }
+
+      function previewNote() {
+        controlTabs.querySelectorAll('li').forEach(el => el.classList.remove('selected'));
+        previewTab.classList.add('selected');
+        noteDisplay.classList.remove('hidden');
+        noteEdit.classList.add('hidden');
+        editForm.classList.add('hidden');
+      }
+
+      function openNote(uuid) {
         noteState = 'edit';
         showNoteEditControls();
-        editControls.create.classList.add('hidden');
-        editControls.save.classList.remove('hidden');
+        noteEdit.classList.remove('hidden');
+        editForm.create.classList.add('hidden');
+        editForm.save.classList.remove('hidden');
+        editForm.note_uuid.value = uuid;
+
+        const query = new URLSearchParams(window.location.search);
+        query.set('note', uuid);
+        const { protocol, host, pathname, hash } = window.location;
+        const newurl = `${protocol}//${host}${pathname}?${query.toString()}${hash}`;
+        window.history.pushState({ path: newurl }, '', newurl);
+
+        const noteCard = noteList.querySelector(`[data-uuid="${uuid}"]`);
+        const { title, public, body } = noteCard && JSON.parse(noteCard.dataset.note);
+        easyMDE.value(body);
+        editForm.note_title.value = title;
+        editForm.note_public.checked = public;
+        updateTitle(title);
+
+        previewNote();
       }
+
       function createNote() {
         noteState = 'new';
         showNoteEditControls();
-        editControls.create.classList.remove('hidden');
-        editControls.save.classList.add('hidden');
+        editNote();
+        editForm.create.classList.remove('hidden');
+        editForm.save.classList.add('hidden');
+
+        editForm.note_title.value = '';
+        editForm.note_public.checked = false;
+        easyMDE.value('');
+        updateTitle('');
       }
+
       function backToList() {
         if (noteState === 'new' || noteState === 'edit-unsaved') {
           if (!confirm('You have unsaved changes! Are you sure you want to go back?')) return;
         }
+
         noteState = 'list';
         noteList.classList.remove('hidden');
         noteEdit.classList.add('hidden');
-        editControls.classList.add('hidden');
+        noteDisplay.classList.add('hidden');
+        editForm.classList.add('hidden');
         controlTabs.classList.add('hidden');
         editTab.classList.remove('selected');
         leftBtn.firstChild.innerText = 'Create Note';
+
+        const query = new URLSearchParams(window.location.search);
+        query.delete('note');
+        const { protocol, host, pathname, hash } = window.location;
+        const newurl = `${protocol}//${host}${pathname}?${query.toString()}${hash}`;
+        window.history.pushState({ path: newurl }, '', newurl);
       }
+
 
       leftBtn.addEventListener('click', () => {
         if (noteState === 'list') createNote();
         else backToList();
       });
 
-      editTab.addEventListener('click', () => {
-        controlTabs.querySelectorAll('li').forEach(el => el.classList.remove('selected'));
-        editTab.classList.add('selected');
-        noteDisplay.classList.add('hidden');
-        noteEdit.classList.remove('hidden');
+      editTab.addEventListener('click', editNote);
+      previewTab.addEventListener('click', previewNote);
+
+      noteList.querySelectorAll('.card').forEach((el) => {
+        el.addEventListener('click', () => {
+          openNote(el.dataset.uuid);
+        });
       });
 
-      previewTab.addEventListener('click', () => {
-        controlTabs.querySelectorAll('li').forEach(el => el.classList.remove('selected'));
-        previewTab.classList.add('selected');
-        noteDisplay.classList.remove('hidden');
-        noteEdit.classList.add('hidden');
-      });
+      const query = new URLSearchParams(window.location.search);
+      const uuid = query.get('note');
+      if (uuid) {
+        openNote(uuid);
+      }
+
         
-      document.querySelectorAll('.note').forEach((el) => {
-        loadMarkdown(el, '#{universe.shortname}', el.dataset.val, null);
+      document.querySelectorAll('#note-list .body').forEach(async (el) => {
+        const tmp = createElement('div');
+        await loadMarkdown(tmp, '#{universe && universe.shortname}', el.dataset.val, null);
+        const text = tmp.textContent;
+        const maxLength = 100;
+        el.textContent = text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
       });
     })();

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -186,7 +186,7 @@ block append styles
         //- const { title, public, body, author_id } = noteCard && JSON.parse(noteCard.dataset.note);
         loadingNote();
         const [, note] = await getJSON(`#{noteBaseRoute}/${uuid}`);
-        const { title, public, body, author_id } = note;
+        const { title, public, body, author_id, items, boards } = note;
         easyMDE.value(body);
         editForm.note_title.value = title;
         editForm.note_public.checked = public;

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -1,0 +1,12 @@
+block append scripts
+  script.
+    function
+
+.notes
+  .sheet
+  .sheet
+    ul.navbarBtns.flex-col.gap-2
+      li.navbarBtn.big-text
+        h3.link.link-animated.ma-0( onclick='newNote()' ) New Note
+      li.navbarBtn.big-text
+        h3.link.link-animated.ma-0( onclick='listNotes()' ) List Notes

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -1,6 +1,46 @@
+block append styles
+  style.
+    #note-list .card>.body {
+      white-space: nowrap;
+      overflow: hidden;
+      mask-image: linear-gradient(135deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 85%, rgba(0, 0, 0, 0) 97%);
+    }
+
+    #notes-left-btn.hidden {
+      display: inline !important;
+      visibility: hidden;
+    }
+
+    .loader {
+      width: 50px;
+      height: 50px;
+      border-radius: 50%;
+      border: 8px solid #0000;
+      border-right-color: #00669997;
+      position: relative;
+      animation: s4 1s infinite linear;
+    }
+    .loader:before,
+    .loader:after {
+      content: "";
+      position: absolute;
+      inset:-8px;
+      border-radius: 50%;
+      border:inherit;
+      animation:inherit;
+      animation-duration: 2s;
+    }
+    .loader:after {
+      animation-duration: 4s;
+    }
+
+    @keyframes s4 {
+      100% {transform: rotate(1turn)}
+    }
+
 .notes
-  p.ma-0.pa-1#notes-left-btn
-    a.link.link-animated Create Note
+  p.ma-0.pa-1
+    a.link.link-animated#notes-left-btn Create Note
 
   div
     #note-control-tabs.hidden
@@ -15,7 +55,7 @@
       each note in notes
         .sheet.card.d-flex.flex-col.gap-1( data-uuid=note.uuid data-note=note )
           h2.ma-0 #{note.title}
-          span
+          small
             b Author: 
             a.link.link-animated( href=`/users/${noteAuthors[note.author_id].username}` ) #{noteAuthors[note.author_id].username}
             |  — 
@@ -28,6 +68,8 @@
       h1.title
       hr
       .body
+    #note-loading.sheet.d-flex.justify-center.hidden
+      .loader
 
   div
     #note-controls.sheet( style={ position: 'sticky', top: '4rem' } )
@@ -54,8 +96,6 @@
   script.
     (async function() {
       if (!window.createElement) throw 'domUtils not loaded!';
-      if (!window.createSearchableSelect) throw 'searchableSelect not loaded!';
-      if (!window.modal) throw 'modal not loaded!';
       if (!window.getJSON) throw 'fetchUtils.js not loaded!';
       if (!window.setupEasyMDE) throw 'easyMDE.js not loaded!';
       if (!window.parseMarkdown) throw 'markdown/parse.js not loaded!';
@@ -66,6 +106,7 @@
       const noteList = document.querySelector('#note-list');
       const noteEdit = document.querySelector('#note-edit');
       const noteDisplay = document.querySelector('#note-display');
+      const noteLoading = document.querySelector('#note-loading');
 
       const noteControls = document.querySelector('#note-controls');
       const editForm = noteControls.querySelector('.edit');
@@ -80,17 +121,15 @@
       }
       const displayNodes = await loadMarkdown(noteDisplay.querySelector('.body'), '#{universe && universe.shortname}', '', null);
       async function updateDisplay(markdown) {
-        const data = await parseMarkdown(markdown).evaluate('#{universe.shortname}', null);
+        const data = await parseMarkdown(markdown).evaluate('#{universe && universe.shortname}', null);
         displayNodes.update(data);
         displayNodes.render();
       }
       editForm.note_title.addEventListener('change', () => {
         updateTitle(editForm.note_title.value);
       });
-      const easyMDE = setupEasyMDE('#note-edit textarea', {universe, context: { item }});
+      const easyMDE = setupEasyMDE('#note-edit textarea', { universe: !{JSON.stringify(universe || null)}, context: { item: !{JSON.stringify(item || null)} }});
       easyMDE.codemirror.on('change', () => {
-        const text = easyMDE.value();
-        if (text.length > 2000) easyMDE.value(text.substring(0, 2000));
         updateDisplay(easyMDE.value());
         editForm.note_body.value = easyMDE.value();
       });
@@ -99,10 +138,11 @@
       function showNoteEditControls() {
         noteList.classList.add('hidden');
         controlTabs.classList.remove('hidden');
-        leftBtn.firstChild.innerText = 'Back to List';
+        leftBtn.innerText = 'Back to List';
       }
 
       function editNote() {
+        noteLoading.classList.add('hidden');
         controlTabs.querySelectorAll('li').forEach(el => el.classList.remove('selected'));
         editTab.classList.add('selected');
         noteDisplay.classList.add('hidden');
@@ -111,6 +151,7 @@
       }
 
       function previewNote() {
+        noteLoading.classList.add('hidden');
         controlTabs.querySelectorAll('li').forEach(el => el.classList.remove('selected'));
         previewTab.classList.add('selected');
         noteDisplay.classList.remove('hidden');
@@ -118,8 +159,17 @@
         editForm.classList.add('hidden');
       }
 
-      function openNote(uuid) {
-        noteState = 'edit';
+      function loadingNote() {
+        noteLoading.classList.remove('hidden');
+        controlTabs.classList.add('hidden');
+        noteDisplay.classList.add('hidden');
+        noteEdit.classList.add('hidden');
+        editForm.classList.add('hidden');
+      }
+
+      async function openNote(uuid) {
+        noteState = 'loading';
+        leftBtn.classList.add('hidden');
         showNoteEditControls();
         noteEdit.classList.remove('hidden');
         editForm.create.classList.add('hidden');
@@ -132,13 +182,18 @@
         const newurl = `${protocol}//${host}${pathname}?${query.toString()}${hash}`;
         window.history.pushState({ path: newurl }, '', newurl);
 
-        const noteCard = noteList.querySelector(`[data-uuid="${uuid}"]`);
-        const { title, public, body, author_id } = noteCard && JSON.parse(noteCard.dataset.note);
+        //- const noteCard = noteList.querySelector(`[data-uuid="${uuid}"]`);
+        //- const { title, public, body, author_id } = noteCard && JSON.parse(noteCard.dataset.note);
+        loadingNote();
+        const [, note] = await getJSON(`#{noteBaseRoute}/${uuid}`);
+        const { title, public, body, author_id } = note;
         easyMDE.value(body);
         editForm.note_title.value = title;
         editForm.note_public.checked = public;
         updateTitle(title);
-        if (author_id !== #{contextUser.id}) controlTabs.classList.add('hidden');
+        if (author_id === #{contextUser.id}) controlTabs.classList.remove('hidden');
+        noteState = 'edit';
+        leftBtn.classList.remove('hidden');
 
         previewNote();
       }
@@ -162,13 +217,14 @@
         }
 
         noteState = 'list';
+        noteLoading.classList.add('hidden');
         noteList.classList.remove('hidden');
         noteEdit.classList.add('hidden');
         noteDisplay.classList.add('hidden');
         editForm.classList.add('hidden');
         controlTabs.classList.add('hidden');
         editTab.classList.remove('selected');
-        leftBtn.firstChild.innerText = 'Create Note';
+        leftBtn.innerText = 'Create Note';
 
         const query = new URLSearchParams(window.location.search);
         query.delete('note');
@@ -179,7 +235,8 @@
 
 
       leftBtn.addEventListener('click', () => {
-        if (noteState === 'list') createNote();
+        if (noteState === 'loading') return;
+        else if (noteState === 'list') createNote();
         else backToList();
       });
 
@@ -201,10 +258,8 @@
         
       document.querySelectorAll('#note-list .card').forEach(async (el) => {
         const body = el.querySelector('.body');
-        const tmp = createElement('div');
-        await loadMarkdown(tmp, '#{universe && universe.shortname}', JSON.parse(el.dataset.note).body, null);
-        const text = tmp.textContent;
-        const maxLength = 100;
-        body.textContent = text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
+        const text = await renderMdPreview('#{universe && universe.shortname}', JSON.parse(el.dataset.note).body, null);
+        const maxLength = 127;
+        body.innerText = text.length >= maxLength ? `${text.substring(0, maxLength)}...` : text;
       });
     })();

--- a/templates/edit/item.pug
+++ b/templates/edit/item.pug
@@ -36,6 +36,12 @@ block content
       label( for='tags' ) Tags: 
       textarea( id='tags' name='tags' ) #{(item.tags || []).join(' ')}
 
+    div.inputGroup
+      label( for='comments' ) Comments enabled: 
+      label.switch
+        input( id='comments' name='comments' type='checkbox' checked=item.obj_data.comments onchange='updateObjData({ comments: this.checked })' )
+        span.slider
+    
     hr.w-100.mb-0
 
     div#tabs
@@ -59,7 +65,7 @@ block content
         .sheet.d-flex.flex-col.gap-1( style={'min-width': '20rem'} )
           select( id='new_tab_type' onchange='handleTypeChange()' )
             option( hidden disabled selected value ) #{T('Tab Type')}...
-            each type in ['body', 'lineage', 'location', 'timeline', 'gallery', 'comments']
+            each type in ['body', 'lineage', 'location', 'timeline', 'gallery']
               option( value=type )= type === 'body' ? 'Main Text' : capitalize(T(type))
             option( value='custom' )= T('Custom Data')
           input( id='new_tab' type='text' placeholder='Tab Name' ).hidden

--- a/templates/edit/item.pug
+++ b/templates/edit/item.pug
@@ -41,14 +41,14 @@ block content
       label.switch
         input( id='comments' name='comments' type='checkbox' checked=item.obj_data.comments onchange='updateObjData({ comments: this.checked })' )
         span.slider
-    
-    hr.w-100.mb-0
 
     div.inputGroup
       label( for='notes' ) Enable notes: 
       label.switch
         input( id='notes' name='notes' type='checkbox' checked=item.obj_data.notes onchange='updateObjData({ notes: this.checked })' )
         span.slider
+    
+    hr.w-100.mb-0
 
     div#tabs
       div#new-tab-modal

--- a/templates/edit/item.pug
+++ b/templates/edit/item.pug
@@ -37,12 +37,18 @@ block content
       textarea( id='tags' name='tags' ) #{(item.tags || []).join(' ')}
 
     div.inputGroup
-      label( for='comments' ) Comments enabled: 
+      label( for='comments' ) Enable comments: 
       label.switch
         input( id='comments' name='comments' type='checkbox' checked=item.obj_data.comments onchange='updateObjData({ comments: this.checked })' )
         span.slider
     
     hr.w-100.mb-0
+
+    div.inputGroup
+      label( for='notes' ) Enable notes: 
+      label.switch
+        input( id='notes' name='notes' type='checkbox' checked=item.obj_data.notes onchange='updateObjData({ notes: this.checked })' )
+        span.slider
 
     div#tabs
       div#new-tab-modal

--- a/templates/index.js
+++ b/templates/index.js
@@ -108,6 +108,7 @@ const templates = {
   contactList: compile('templates/list/contacts.pug'),
 
   search: compile('templates/list/search.pug'),
+  notes: compile('templates/list/notes.pug'),
   verify: compile('templates/verify.pug'),
   settings: compile('templates/edit/settings.pug'),
 };

--- a/templates/layout.pug
+++ b/templates/layout.pug
@@ -65,6 +65,8 @@ html(lang='en')
           li.navbarBtn
             a.navbarBtnLink.navbarText(href=`${ADDR_PREFIX}/items`) Items
           li.navbarBtn
+            a.navbarBtnLink.navbarText(href=`${ADDR_PREFIX}/notes`) Notes
+          li.navbarBtn
             a.navbarBtnLink.navbarText(href=`https://github.com/JoelNiemela/archivium/wiki` target='_blank') Help
         ul.navbarBtns
           block save

--- a/templates/list/notes.pug
+++ b/templates/list/notes.pug
@@ -1,0 +1,24 @@
+extends ../layout.pug
+
+block styles
+  link( rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css" )
+
+block scripts
+  script( src="https://unpkg.com/easymde/dist/easymde.min.js" )
+  script
+    include /static/scripts/domUtils.js
+    include /static/scripts/fetchUtils.js
+    include /static/scripts/markdown/parse.js
+    include /static/scripts/markdown/render.js
+    include /static/scripts/cardUtils.js
+    include /static/scripts/easyMDE.js
+
+block breadcrumbs
+  a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
+  |  / 
+  a.link.link-animated( href=`${ADDR_PREFIX}/notes` ) #{T('Notes')}
+
+block content
+  h1.center Notes
+  
+  include ../components/notes.pug

--- a/templates/list/notes.pug
+++ b/templates/list/notes.pug
@@ -12,6 +12,7 @@ block scripts
     include /static/scripts/markdown/render.js
     include /static/scripts/cardUtils.js
     include /static/scripts/easyMDE.js
+    include /static/scripts/searchableSelect.js
 
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -76,7 +76,7 @@ block content
       if dataType in item.obj_data && 'title' in item.obj_data[dataType]
         li.navbarBtn( data-tab=dataType )
           h3.navbarBtnLink.navbarText.ma-0( onclick=`showTab('${dataType}')` ) #{item.obj_data[dataType].title}
-    if 'comments' in item.obj_data && 'title' in item.obj_data.comments
+    if item.obj_data.comments
       li.navbarBtn( data-tab='comments' )
         h3.navbarBtnLink.navbarText.ma-0( onclick=`showTab('comments')` ) #{capitalize(T('comments'))}
 
@@ -124,7 +124,7 @@ block content
             a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/items/${child.child_shortname}` )
               | #{child.child_title}
         
-    if 'comments' in item.obj_data && 'title' in item.obj_data.comments
+    if item.obj_data.comments
       .hidden( data-tab='comments' )
         include ../components/comments.pug
 

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -80,9 +80,11 @@ block content
     if item.obj_data.comments
       li.navbarBtn( data-tab='comments' )
         h3.navbarBtnLink.navbarText.ma-0( onclick=`showTab('comments')` ) #{capitalize(T('comments'))}
-    if item.obj_data.notes
+    if item.obj_data.notes || (contextUser && universe.author_permissions[contextUser.id] >= perms.WRITE && notes.length > 0)
       li.navbarBtn( data-tab='notes' )
           h3.navbarBtnLink.navbarText.ma-0( onclick=`showTab('notes')` ) #{capitalize(T('notes'))}
+            if !item.obj_data.notes
+              |  (Hidden)
 
   
   script!= `window.item = ${JSON.stringify(item)};`
@@ -133,8 +135,14 @@ block content
       .hidden( data-tab='comments' )
         include ../components/comments.pug
         
-    if item.obj_data.notes
+    if item.obj_data.notes || (contextUser && universe.author_permissions[contextUser.id] >= perms.WRITE && notes.length > 0)
       .hidden( data-tab='notes' )
+        if !item.obj_data.notes
+          .center
+            .ma-auto.my-2( style={ 'max-width': '32rem' } )
+              small
+                i This tab is visible to you since this item has notes linked to it and you have edit access. 
+                  | To make this tab visible to everyone, enable notes for this item.
         include ../components/notes.pug
 
     if 'body' in item.obj_data

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -79,6 +79,9 @@ block content
     if item.obj_data.comments
       li.navbarBtn( data-tab='comments' )
         h3.navbarBtnLink.navbarText.ma-0( onclick=`showTab('comments')` ) #{capitalize(T('comments'))}
+    if item.obj_data.notes
+      li.navbarBtn( data-tab='notes' )
+          h3.navbarBtnLink.navbarText.ma-0( onclick=`showTab('notes')` ) #{capitalize(T('notes'))}
 
   
   script!= `window.item = ${JSON.stringify(item)};`
@@ -127,6 +130,10 @@ block content
     if item.obj_data.comments
       .hidden( data-tab='comments' )
         include ../components/comments.pug
+        
+    if item.obj_data.notes
+      .hidden( data-tab='notes' )
+        include ../components/notes.pug
 
     if 'body' in item.obj_data
       .sheet.hidden( data-tab='body' )

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -1,6 +1,6 @@
 extends ../layout.pug
 
-block styles
+block append styles
   link( rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css" )
   style.
     .tags-and-icons {

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -25,6 +25,7 @@ block scripts
     include /static/scripts/calendarPicker.js
     include /static/scripts/timelineRender.js
     include /static/scripts/cardUtils.js
+    include /static/scripts/easyMDE.js
     //- include /static/scripts/editor/rich.js
 
 block breadcrumbs
@@ -85,6 +86,7 @@ block content
 
   
   script!= `window.item = ${JSON.stringify(item)};`
+  script!= `window.universe = ${JSON.stringify(universe)};`
 
   .tabs
     if 'tabs' in item.obj_data
@@ -161,11 +163,6 @@ block content
           }
           if (tag.type === 'p') tag.type = 'span';
         });
-      });
-      
-      document.querySelectorAll('.comment').forEach((el) => {
-        console.log(el.dataset.val)
-        loadMarkdown(el, '#{universe.shortname}', el.dataset.val, null);
       });
 
       const galleryModalState = {}

--- a/templates/view/universeThread.pug
+++ b/templates/view/universeThread.pug
@@ -22,8 +22,3 @@ block content
   h2 #{thread.title}
 
   include ../components/comments.pug
-
-  script.
-    document.querySelectorAll('.comment').forEach((el) => {
-      loadMarkdown(el, '#{universe.shortname}', el.dataset.val, null);
-    });

--- a/views.js
+++ b/views.js
@@ -419,7 +419,7 @@ module.exports = function(app) {
       commenters[user.id] = user;
     }
 
-    const [code4, notes, noteUsers] = await api.note.getByItemShortname(req.session.user, universe.shortname, item.shortname, {}, false, true);
+    const [code4, notes, noteUsers] = await api.note.getByItemShortname(req.session.user, universe.shortname, item.shortname, {}, {}, true);
     if (!notes || !noteUsers) return res.status(code4);
     const noteAuthors = {};
     for (const user of noteUsers) {
@@ -431,6 +431,7 @@ module.exports = function(app) {
     res.prepareRender('item', {
       item, universe, tab: req.query.tab, comments, commenters, notes, noteAuthors,
       commentAction: `/universes/${universe.shortname}/items/${item.shortname}/comment`,
+      noteBaseRoute: `/api/universes/${universe.shortname}/items/${item.shortname}/notes`,
     });
   });
   get('/universes/:universeShortname/items/:itemShortname/edit', Auth.verifySessionOrRedirect, async (req, res) => {

--- a/views.js
+++ b/views.js
@@ -540,10 +540,10 @@ module.exports = function(app) {
     if (body.note_board && body.note_universe) {
       const [code, data] = await api.note.linkToBoard(session.user, body.note_board, uuid);
       if (code !== 201) return console.error(`Error ${code}: ${data}`);
-      nextPage = nextPage || `${ADDR_PREFIX}/universes/${body.note_universe}/notes/${body.note_board}/${uuid}`;
+      nextPage = nextPage || `${ADDR_PREFIX}/universes/${body.note_universe}/notes/${body.note_board}?note=${uuid}`;
     }
     res.status(code);
-    if (code === 201) return res.redirect(nextPage || `${ADDR_PREFIX}/notes/${uuid}`);
+    if (code === 201) return res.redirect(nextPage || `${ADDR_PREFIX}/notes?note=${uuid}`);
     return console.error(`Error ${code}: ${data}`);
     // res.prepareRender('createUniverse', { error: data, ...req.body });
   });
@@ -553,16 +553,18 @@ module.exports = function(app) {
       title: body.note_title,
       public: body.note_public === 'on',
       body: body.note_body,
+      items: body.items,
+      boards: body.boards,
     });
     let nextPage;
     if (body.note_item && body.note_universe) {
       nextPage = nextPage || `${ADDR_PREFIX}/universes/${body.note_universe}/items/${body.note_item}?tab=notes&note=${body.note_uuid}`;
     }
     if (body.note_board && body.note_universe) {
-      nextPage = nextPage || `${ADDR_PREFIX}/universes/${body.note_universe}/notes/${body.note_board}/${body.note_uuid}`;
+      nextPage = nextPage || `${ADDR_PREFIX}/universes/${body.note_universe}/notes/${body.note_board}?note=${body.note_uuid}`;
     }
     res.status(code);
-    if (code === 200) return res.redirect(nextPage || `${ADDR_PREFIX}/notes/${body.note_uuid}`);
+    if (code === 200) return res.redirect(nextPage || `${ADDR_PREFIX}/notes?note=${body.note_uuid}`);
     return console.error(`Error ${code}: ${data}`);
     // res.prepareRender('createUniverse', { error: data, ...req.body });
   });

--- a/views.js
+++ b/views.js
@@ -555,6 +555,7 @@ module.exports = function(app) {
       body: body.note_body,
       items: body.items,
       boards: body.boards,
+      tags: body.note_tags?.split(' ') ?? [],
     });
     let nextPage;
     if (body.note_item && body.note_universe) {

--- a/views.js
+++ b/views.js
@@ -512,6 +512,18 @@ module.exports = function(app) {
   });
 
   /* Note pages */
+  get('/notes', Auth.verifySessionOrRedirect, async (req, res) => {
+    const user = req.session.user;
+    const [code, notes] = await api.note.getByUsername(user, user.username);
+    const noteAuthors = { [user.id]: user };
+    res.status(code);
+    if (!notes) return;
+    res.prepareRender('notes', {
+      notes,
+      noteAuthors,
+      noteBaseRoute: `/api/users/${user.username}/notes`,
+    });
+  });
   post('/notes/create', Auth.verifySessionOrRedirect, async (req, res) => {
     const { body, session } = req;
     const [code, data, uuid] = await api.note.post(session.user, {

--- a/views.js
+++ b/views.js
@@ -530,6 +530,7 @@ module.exports = function(app) {
       title: body.note_title,
       public: body.note_public === 'on',
       body: body.note_body,
+      tags: body.note_tags?.split(' ') ?? [],
     });
     let nextPage;
     if (body.note_item && body.note_universe) {

--- a/views.js
+++ b/views.js
@@ -410,16 +410,27 @@ module.exports = function(app) {
     if (item.gallery.length > 0) {
       item.gallery = item.gallery.sort((a, b) => a.id > b.id ? 1 : -1);
     }
-    const [code3, comments, users] = await api.discussion.getCommentsByItem(req.session.user, item.id, false, true);
-    if (!comments || !users) return [code3];
+
+    const [code3, comments, commentUsers] = await api.discussion.getCommentsByItem(req.session.user, item.id, false, true);
+    if (!comments || !commentUsers) return res.status(code3);
     const commenters = {};
-    for (const user of users) {
+    for (const user of commentUsers) {
       user.pfpUrl = getPfpUrl(user);
       delete user.email;
       commenters[user.id] = user;
     }
+
+    const [code4, notes, noteUsers] = await api.note.getByItemShortname(req.session.user, universe.shortname, item.shortname, {}, false, true);
+    if (!notes || !noteUsers) return res.status(code4);
+    const noteAuthors = {};
+    for (const user of noteUsers) {
+      user.pfpUrl = getPfpUrl(user);
+      delete user.email;
+      noteAuthors[user.id] = user;
+    }
+
     res.prepareRender('item', {
-      item, universe, tab: req.query.tab, comments, commenters,
+      item, universe, tab: req.query.tab, comments, commenters, notes, noteAuthors,
       commentAction: `/universes/${universe.shortname}/items/${item.shortname}/comment`,
     });
   });


### PR DESCRIPTION
closes #101

Add note tables and API. Notes have a text body and can be "pinned" to either note boards (belonging to a universe) or items. A note can be private, meaning only the user that created it can see it, or public, meaning any user who has access to a board or item a note is pinned to can see it.

@JoelNiemela The note editor is currently implemented as a SPA component, mostly to make it easier to add to the notes page. It probably could pretty straightforwardly be refactored to be multi-page, but unless you feel strongly that this should be done I don't see a need to.

Also, disable the easyMDE spellchecker as it is mostly a nuisance (#101).

I'm not sure what we actually want to do with the note boards feature, so I'm leaving that for later (#105)