### PR TITLE
Fix scrolling headings into view

### DIFF
--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -3,6 +3,7 @@
 
 :root {
   --navbar-height: 51px;
+  --page-margin-top: calc(var(--navbar-height) + 1rem);
 }
 
 * {
@@ -11,6 +12,7 @@
 
 h1, h2, h3, h4, h5, h6, .lora {
   font-family: 'Lora', serif;
+  scroll-margin-top: var(--page-margin-top);
 }
 
 body {
@@ -23,7 +25,7 @@ body {
 }
 
 main {
-  margin: calc(var(--navbar-height) + 1rem) 0 2rem;
+  margin: var(--page-margin-top) 0 2rem;
   flex-grow: 1;
 }
 

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -1,6 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
 
+:root {
+  --navbar-height: 51px;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -19,7 +23,7 @@ body {
 }
 
 main {
-  margin: 0 0 2rem;
+  margin: calc(var(--navbar-height) + 1rem) 0 2rem;
   flex-grow: 1;
 }
 
@@ -63,11 +67,10 @@ footer {
 }
 
 header {
-  position: sticky;
-  margin: 0.5rem;
-  top: -0.0625rem;
+  position: fixed;
+  width: 100%;
   z-index: 3;
-  transition: margin 0.1s;
+  background-color: #e9e9e9;
 }
 
 .navbar {
@@ -76,13 +79,7 @@ header {
   border: 0.0625rem solid #e7e7e7;
   border-radius: 0.25rem;
   background-color: #f3f3f3;
-}
-
-.nav-fullwidth {
-  margin: 0.5rem 0;
-  border-right: none;
-  border-left: none;
-  border-radius: 0;
+  max-height: var(--navbar-height);
 }
 
 .navbarBtns {
@@ -988,6 +985,10 @@ input:checked + .slider:before {
 .ma-1 {
   margin: 0.25rem;
 }
+.ma-2 {
+  margin: 0.5rem;
+}
+
 
 .my-1 {
   margin-top: 0.25rem;

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -6,6 +6,12 @@
   --page-margin-top: calc(var(--navbar-height) + 1rem);
 }
 
+@media only screen and (max-device-width: 480px) {
+  :root {
+    --navbar-height: 102px;
+  }
+}
+
 * {
   box-sizing: border-box;
 }

--- a/static/scripts/markdown/parse.js
+++ b/static/scripts/markdown/parse.js
@@ -120,7 +120,7 @@ if (!window.getJSON) throw 'fetchUtils.js not loaded!';
             });
           }
         } else {
-          if (!this.attrs.href.startsWith('/') && !this.attrs.href.startsWith(window.location.origin)) {
+          if (!this.attrs.href.startsWith('/') && !this.attrs.href.startsWith('#') && !this.attrs.href.startsWith(window.location.origin)) {
             this.attrs.target = '_blank';
           }
         }

--- a/static/scripts/tabs.js
+++ b/static/scripts/tabs.js
@@ -10,16 +10,20 @@ function showTab(tab) {
   window.history.pushState({ path: newurl }, '', newurl);
 }
 
-window.addEventListener('load', () => {
-  const query = new URLSearchParams(window.location.search);
-  const defaultTab = query.get('tab');
+const tabLoadPromise = new Promise((resolve) => {
+  window.addEventListener('load', () => {
+    const query = new URLSearchParams(window.location.search);
+    const defaultTab = query.get('tab');
 
-  const tabs = document.getElementById('tabBtns');
-  if (tabs.children.length > 0) {
-    showTab(defaultTab || tabs.children[0].dataset.tab)
-  }
+    const tabs = document.getElementById('tabBtns');
+    if (tabs.children.length > 0) {
+      showTab(defaultTab || tabs.children[0].dataset.tab)
+    }
 
-  if (tabs.children.length < 2) {
-    tabs.remove();
-  }
+    if (tabs.children.length < 2) {
+      tabs.remove();
+    }
+
+    resolve();
+  });
 });

--- a/templates/layout.pug
+++ b/templates/layout.pug
@@ -44,15 +44,7 @@ html(lang='en')
 
   body
     header
-      nav.navbar
-        script.
-          window.onscroll = () => {
-            if (document.body.scrollTop > 8 || document.documentElement.scrollTop > 8) {
-              document.querySelector('header').classList.add('nav-fullwidth');
-            } else {
-              document.querySelector('header').classList.remove('nav-fullwidth');
-            }
-          }
+      nav.navbar.ma-2.mb-0
         ul.navbarBtns.shrink-1.scroll-x
           li.navbarBtn
             a.navbarBtnLink.navbarText(href=`${ADDR_PREFIX}/`) Home

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -153,7 +153,15 @@ block content
     (function() {
       const body = document.getElementById('markdown-body');
       if (body) {
-        loadMarkdown(body, '#{universe.shortname}', item.obj_data.body, { item });
+        loadMarkdown(body, '#{universe.shortname}', item.obj_data.body, { item }).then(async () => {
+          await tabLoadPromise;
+          const hash = location.hash.substr(1);
+          if (hash) {
+            const el = document.getElementById(hash);
+            console.log(hash, el)
+            el.scrollIntoView();
+          }
+        });
       };
 
       document.querySelectorAll('.mdVal').forEach((el) => {


### PR DESCRIPTION
fixes #103, fixes #114

- Undo change made in #13 and make navbar fixed on the page again.
- Fix table of content links to not open in a new tab.
- Set scroll margins so headings aren't obscured by navbar when scrolled to.
- Programmatically scroll heading into view for item pages.