### PR TITLE
Improve login and signup pages

### DIFF
--- a/api/models/user.js
+++ b/api/models/user.js
@@ -100,8 +100,8 @@ async function getByUniverseShortname(user, shortname) {
 function post({ username, email, password, hp }) {
   const salt = utils.createRandom32String();
 
-  if (!username) throw new Error('malformed username');
-  if (!email) throw new Error('malformed email');
+  if (!username) throw new Error('username is required');
+  if (!email) throw new Error('email is required');
   if (!password) throw new Error('empty password not allowed');
 
   const validationError = validateUsername(username);
@@ -165,7 +165,6 @@ function validateUsername(username) {
     return 'Usernames cannot start or end with a dash.';
   }
 
-  // const USERNAME_REGEX = /^(?!.*[-_]{2,})(?!.*[_.-]$)(?!^[-_.])(?!^\d+$)[a-zA-Z0-9_-]{3,32}$/;
   if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
       return 'Usernames can only contain letters, numbers, underscores, and hyphens.';
   }

--- a/templates/login.pug
+++ b/templates/login.pug
@@ -2,10 +2,15 @@ extends layout.pug
 
 block content
   h2 Login
-  form( method='post' )
+  form#login( method='post' )
     div.inputGroup
       label( for='username' ) Username: 
       input( id='username' type='text' name='username' )
+      script.
+        const form = document.forms.login;
+        form.username.addEventListener('input', () => {
+          form.username.value = form.username.value.trim();
+        })
     div.inputGroup
       label( for='password' ) Password: 
       input( id='password' type='password' name='password' )

--- a/templates/signup.pug
+++ b/templates/signup.pug
@@ -46,6 +46,7 @@ block content
         const form = document.forms.signup;
         const formError = document.querySelector('#error');
         form.username.addEventListener('input', () => {
+          form.username.value = form.username.value.trim();
           formError.classList.add('hidden');
           const value = form.username.value;
           const error = validateUsername(value);


### PR DESCRIPTION
Prevent the user from entering spaces into the username fields on the login and signup pages, since these aren't allowed in usernames anyway and may make it hard for users to figure out why their login attempts are refused.