### PR TITLE
Home Page

### DIFF
--- a/api/models/universe.js
+++ b/api/models/universe.js
@@ -110,14 +110,14 @@ async function getEventsByUniverseShortname(user, shortname, permissionsRequired
   }
 }
 
-async function getPublicPageByShortname(shortname) {
+async function getPublicBodyByShortname(shortname) {
   try {
     const queryString = `SELECT obj_data FROM universe WHERE shortname = ?`;
-    const data = (await executeQuery(queryString, [shortname]))[0];
-    if (!data) return 404;
-    const page = data.obj_data?.publicPage;
-    if (!page) return [401];
-    return [200, page];
+    const rows = (await executeQuery(queryString, [shortname]))[0];
+    if (!rows) return 404;
+    const body = JSON.parse(rows.obj_data)?.publicBody;
+    if (!body) return [401];
+    return [200, body];
   } catch (err) {
     logger.error(err);
     return [500];
@@ -393,7 +393,7 @@ module.exports = {
   getManyByAuthorId,
   getManyByAuthorName,
   getEventsByUniverseShortname,
-  getPublicPageByShortname,
+  getPublicBodyByShortname,
   validateShortname,
   post,
   put,

--- a/api/models/universe.js
+++ b/api/models/universe.js
@@ -110,6 +110,20 @@ async function getEventsByUniverseShortname(user, shortname, permissionsRequired
   }
 }
 
+async function getPublicPageByShortname(shortname) {
+  try {
+    const queryString = `SELECT obj_data FROM universe WHERE shortname = ?`;
+    const data = (await executeQuery(queryString, [shortname]))[0];
+    if (!data) return 404;
+    const page = data.obj_data?.publicPage;
+    if (!page) return [401];
+    return [200, page];
+  } catch (err) {
+    logger.error(err);
+    return [500];
+  }
+}
+
 function validateShortname(shortname, reservedShortnames = []) {
 
   if (shortname.length < 3 || shortname.length > 64) {
@@ -379,6 +393,7 @@ module.exports = {
   getManyByAuthorId,
   getManyByAuthorName,
   getEventsByUniverseShortname,
+  getPublicPageByShortname,
   validateShortname,
   post,
   put,

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -679,7 +679,6 @@ h4, h5 {
 }
 .link.link-animated {
   color: #069;
-  white-space: nowrap;
 }
 .link:not(.link-animated) {
   color: black;
@@ -696,30 +695,21 @@ h4, h5 {
 .link:focus:not(.link-broken):not(.link-animated), .link:hover:not(.link-broken):not(.link-animated) {
   color: #666;
 }
-.link:after.link-broken {
-  color: red;
+.link-animated {
+  text-decoration: none;
+  background-image: linear-gradient(#069, #069);
+  background-size: 100% 0;
+  background-repeat: no-repeat;
+  background-position: 0 calc(100% - 0.125rem);
+  transition: background-size 0.1s ease, background-position-y 0.1s ease;
 }
-.link:after:not(.link-broken) {
-  color: #069;
+.link-animated:hover,
+.link-animated:focus {
+  background-size: 100% 0.125rem;
+  background-position-y: bottom;
 }
-.link-animated:after {
-  content: '';
-  height: 0.125rem;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 0%;
-  background: #069;
-  transition: 0.2s;
-}
-.link-animated.link-broken:after {
-  background: red;
-}
-.link-animated:hover:after {
-  width: 100%;
-}
-.link-animated:focus:after {
-  width: 100%;
+.link-animated.link-broken {
+  background-image: linear-gradient(red, red);
 }
 .link-background {
   padding: 0.1875rem 0.625rem 0.1875rem 0.625rem;

--- a/templates/edit/universe.pug
+++ b/templates/edit/universe.pug
@@ -53,14 +53,14 @@ block content
     #home-body
       h3 Home Page
       .mb-2
-        small This markdown will be shown in the "home" tab of your universe page.
+        small This markdown will be shown in the "Home" tab of your universe page.
       textarea
         | #{universe.obj_data.homeBody || ''}
 
     #public-body
       h3 Public Page
       .mb-2
-        small This markdown will be shown to users that don't have access to your universe.
+        small This markdown will be shown to users that don't have access to your universe instead of the "Access Denied" page.
       textarea
         | #{universe.obj_data.publicBody || ''}
 

--- a/templates/edit/universe.pug
+++ b/templates/edit/universe.pug
@@ -1,6 +1,7 @@
 extends ../layout.pug
 
 block append styles
+  link( rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css" )
   style.
     #cats td {
       padding: 0.125rem 0;
@@ -18,9 +19,11 @@ block append save
     a.navbarBtnLink.navbarText( onclick='document.forms.edit.requestSubmit()' ) Save Changes
 
 block content
+  script( src="https://unpkg.com/easymde/dist/easymde.min.js" )
   script
     include /static/scripts/domUtils.js
     include /static/scripts/universes.js
+    include /static/scripts/easyMDE.js
 
   h2 Edit #{universe.title}
   form#edit( method='POST' )
@@ -46,6 +49,20 @@ block content
       select( id='discussion_open' name='discussion_open' )
         option( value='enabled' selected=(universe.discussion_open) ) Anyone
         option( value='disabled' selected=(!universe.discussion_open) ) Only with COMMENT permission level
+
+    #home-body
+      h3 Home Page
+      .mb-2
+        small This markdown will be shown in the "home" tab of your universe page.
+      textarea
+        | #{universe.obj_data.homeBody || ''}
+
+    #public-body
+      h3 Public Page
+      .mb-2
+        small This markdown will be shown to users that don't have access to your universe.
+      textarea
+        | #{universe.obj_data.publicBody || ''}
 
     h3 Item Types
     small
@@ -86,7 +103,26 @@ block content
       div
         span( style={color: 'red', 'font-size': 'small'} )= error
 
-  script!= `updateObjData(${JSON.stringify(universe.obj_data)});`
+  script.
+    updateObjData(!{JSON.stringify(universe.obj_data)});
+    universe = '!{universe.shortname}';
+
+  script.
+    window.homeMDE = setupEasyMDE('#home-body textarea', { universe });
+    homeMDE.codemirror.on('change', () => {
+      updateObjData({ homeBody: homeMDE.value() });
+    });
+    window.publicMDE = setupEasyMDE('#public-body textarea', { universe });
+    publicMDE.codemirror.on('change', () => {
+      updateObjData({ publicBody: publicMDE.value() });
+    });
+    const publicBodyContainer = document.querySelector('#public-body');
+    publicBodyContainer.classList.toggle('hidden', #{universe.public});
+    const visibilitySelect = document.querySelector('#visibility');
+    visibilitySelect.addEventListener('change', () => {
+      publicBodyContainer.classList.toggle('hidden', visibilitySelect.value !== 'private');
+    });
+
   script.
     function toShortname(title) {
       let shortname = title.toLowerCase()

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -91,7 +91,7 @@ block content
   hr
 
   //- Tab buttons
-  ul#tabBtns.navbarBtns.gap-1.mb-2
+  ul#tabBtns.navbarBtns.gap-1.mb-2.scroll-x
     if 'body' in item.obj_data
       li.navbarBtn#bodyBtn( data-tab='body' )
         h3.navbarBtnLink.navbarText.ma-0( onclick=`showTab('body')` ) Main Text

--- a/templates/view/privateUniverse.pug
+++ b/templates/view/privateUniverse.pug
@@ -1,22 +1,40 @@
 extends ../layout.pug
 
 block scripts
-  script
+  script 
+    include /static/scripts/domUtils.js
     include /static/scripts/fetchUtils.js
+    include /static/scripts/markdown/parse.js
+    include /static/scripts/markdown/render.js
 
 block content
-  div
+  if publicBody
+    br
+    .sheet
+      #md-body
+        script!= `window.content = ${JSON.stringify(publicBody)};`
+        script.
+          loadMarkdown(document.getElementById('md-body'), null, window.content);
+    br
+  else
     .center.d-flex.flex-col.align-center
       span.mt-4.material-symbols-outlined( style={ 'font-size': '8rem' } ) visibility_off
       h1.mt-0 Access Denied
       p 
         | Looks like the universe you're trying to reach is private.
         br
-        | You can ask the owner of this universe for access by clicking the button below:
-
-      script.
-        async function requestAccess() {
-          await putJSON('/api/universes/#{shortname}/request', { permissionLevel: #{perms.READ} });
-          window.location.reload();
-        }
-      button.button.large( type='submit' onclick='requestAccess()' disabled=hasRequested ) #{hasRequested ? T('Request Pending') : T('Request Access')}
+        if contextUser
+          | You can ask the owner of this universe for access by clicking the button below:
+  
+  .center.d-flex.flex-col.align-center
+    if contextUser
+        script.
+          async function requestAccess() {
+            await putJSON('/api/universes/#{shortname}/request', { permissionLevel: #{perms.READ} });
+            window.location.reload();
+          }
+        button.button.large( type='submit' onclick='requestAccess()' disabled=hasRequested ) #{hasRequested ? T('Request Pending') : T('Request Access')}
+    else
+      p
+        a.link.link-animated( href=`${ADDR_PREFIX}/login?${encodedPath}` ) Log in
+        |  to request full access to this universe.

--- a/templates/view/universe.pug
+++ b/templates/view/universe.pug
@@ -22,8 +22,11 @@ block breadcrumbs
 block scripts
   script
     include /static/scripts/tabs.js
+    include /static/scripts/domUtils.js
     include /static/scripts/cardUtils.js
     include /static/scripts/fetchUtils.js
+    include /static/scripts/markdown/parse.js
+    include /static/scripts/markdown/render.js
 
 block content
   h1.center #{universe.title}
@@ -71,6 +74,9 @@ block content
 
   //- Tab buttons
   ul.navbarBtns#tabBtns.gap-1
+    if universe.obj_data.homeBody
+      li.navbarBtn#bodyBtn( data-tab='home' )
+        h3.navbarBtnLink.navbarText( onclick=`showTab('home')` ) Home
     li.navbarBtn#bodyBtn( data-tab='items' )
       h3.navbarBtnLink.navbarText( onclick=`showTab('items')` ) Items
     li.navbarBtn#bodyBtn( data-tab='authors' )
@@ -83,6 +89,14 @@ block content
         h3.navbarBtnLink.navbarText( onclick=`showTab('discuss')` ) Discuss
 
   .tabs
+    .hidden( data-tab='home' )
+      if universe.obj_data.homeBody
+        .sheet
+          #home-body
+            script!= `window.content = ${JSON.stringify(universe.obj_data.homeBody)};`
+            script.
+              loadMarkdown(document.getElementById('home-body'), '#{universe.shortname}', window.content);
+
     .container.hidden( data-tab='items' )
       if universe.obj_data.cats && Object.keys(universe.obj_data.cats).length
         .type-card-container

--- a/templates/view/universe.pug
+++ b/templates/view/universe.pug
@@ -73,7 +73,7 @@ block content
   hr
 
   //- Tab buttons
-  ul.navbarBtns#tabBtns.gap-1
+  ul.navbarBtns#tabBtns.gap-1.scroll-x
     if universe.obj_data.homeBody
       li.navbarBtn#bodyBtn( data-tab='home' )
         h3.navbarBtnLink.navbarText( onclick=`showTab('home')` ) Home

--- a/views/forms.js
+++ b/views/forms.js
@@ -42,23 +42,23 @@ module.exports = {
       discussion_enabled: req.body.discussion_enabled === 'enabled',
       discussion_open: req.body.discussion_open === 'enabled',
     }
-    const [code, data] = await api.universe.put(req.session.user, req.params.shortname, req.body);
+    const [code, data] = await api.universe.put(req.session.user, req.params.universeShortname, req.body);
     res.status(code);
-    if (code === 200) return res.redirect(`${universeLink(req, req.params.shortname)}/`);
+    if (code === 200) return res.redirect(`${universeLink(req, req.params.universeShortname)}/`);
     res.prepareRender('editUniverse', { error: data, ...req.body });
   },
 
   async createUniverseThread(req, res) {
-    const [code1, data] = await api.discussion.postUniverseThread(req.session.user, req.params.shortname, { title: req.body.title });
+    const [code1, data] = await api.discussion.postUniverseThread(req.session.user, req.params.universeShortname, { title: req.body.title });
     res.status(code1);
     if (code1 === 201) {
       if (req.body.comment) {
         const [code2, _] = await api.discussion.postCommentToThread(req.session.user, data.insertId, { body: req.body.comment });
         res.status(code2);
       }
-      return res.redirect(`${universeLink(req, req.params.shortname)}/discuss/${data.insertId}`);
+      return res.redirect(`${universeLink(req, req.params.universeShortname)}/discuss/${data.insertId}`);
     }
-    const [code3, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.shortname });
+    const [code3, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.universeShortname });
     res.status(code3);
     if (code3 !== 200) return;
     res.prepareRender('createUniverseThread', { error: data, ...req.body, universe });
@@ -67,16 +67,16 @@ module.exports = {
   async commentOnThread(req, res) {
     const [code, _] = await api.discussion.postCommentToThread(req.session.user, req.params.threadId, req.body);
     res.status(code);
-    return res.redirect(`${universeLink(req, req.params.shortname)}/discuss/${req.params.threadId}`);
+    return res.redirect(`${universeLink(req, req.params.universeShortname)}/discuss/${req.params.threadId}`);
   },
  
   async createItem(req, res) {
     const [userCode, data] = await api.item.post(req.session.user, {
       ...req.body,
-    }, req.params.shortname);
+    }, req.params.universeShortname);
     res.status(userCode);
-    if (userCode === 201) return res.redirect(`${universeLink(req, req.params.shortname)}/items/${req.body.shortname}`);
-    const [code, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.shortname });
+    if (userCode === 201) return res.redirect(`${universeLink(req, req.params.universeShortname)}/items/${req.body.shortname}`);
+    const [code, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.universeShortname });
     res.status(code);
     if (code !== 200) return;
     res.prepareRender('createItem', { error: data, ...req.body, universe });
@@ -100,10 +100,10 @@ module.exports = {
   async editUniversePerms(req, res) {
     const { session, params, body } = req;
     const [_, user] = await api.user.getOne({ 'user.username': req.body.username });
-    const [code, data] = await api.universe.putPermissions(session.user, params.shortname, user, body.permission_level, perms.ADMIN);
+    const [code, data] = await api.universe.putPermissions(session.user, params.universeShortname, user, body.permission_level, perms.ADMIN);
     res.status(code);
     if (code !== 200) return;
-    res.redirect(`${universeLink(req, params.shortname)}/permissions`);
+    res.redirect(`${universeLink(req, params.universeShortname)}/permissions`);
   },
 
   async createNote(req, res) {

--- a/views/pages/item.js
+++ b/views/pages/item.js
@@ -37,7 +37,7 @@ module.exports = {
   },
 
   async create(req, res) {
-    const [code, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.shortname }, perms.WRITE);
+    const [code, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.universeShortname }, perms.WRITE);
     res.status(code);
     if (code !== 200) return;
     res.prepareRender('createItem', { universe, item_type: req.query.type, shortname: req.query.shortname });

--- a/views/pages/universe.js
+++ b/views/pages/universe.js
@@ -20,12 +20,20 @@ module.exports = {
   },
   
   async view(req, res) {
-    const [code1, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.shortname });
+    const [code1, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.universeShortname });
     res.status(code1);
     if (code1 === 403) {
       res.status(200);
-      const [, request] = await api.universe.getUserAccessRequest(req.session.user, req.params.shortname);
-      return res.prepareRender('privateUniverse', { shortname: req.params.shortname, hasRequested: Boolean(request) });
+      const [, request] = await api.universe.getUserAccessRequest(req.session.user, req.params.universeShortname);
+      return res.prepareRender('privateUniverse', { shortname: req.params.universeShortname, hasRequested: Boolean(request) });
+    } else if (code1 === 401) {
+      const [code, publicPage] = await api.universe.getPublicPageByShortname(req.params.universeShortname);
+      res.status(code);
+      req.forceLogin = true;
+      req.useExQuery = true;
+      console.log(publicPage, req.path, req.query)
+      console.log(req.path)
+      return;
     }
     else if (!universe) return;
     const [code2, authors] = await api.user.getByUniverseShortname(req.session.user, universe.shortname);
@@ -46,21 +54,21 @@ module.exports = {
   },
 
   async delete(req, res) {
-    const [code, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.shortname }, perms.ADMIN);
+    const [code, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.universeShortname }, perms.ADMIN);
     res.status(code);
     if (!universe) return res.redirect(`${ADDR_PREFIX}/universes`);
     res.prepareRender('deleteUniverse', { universe });
   },
 
   async edit(req, res) {
-    const [code, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.shortname }, perms.WRITE);
+    const [code, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.universeShortname }, perms.WRITE);
     res.status(code);
     if (!universe) return;
     res.prepareRender('editUniverse', { universe });
   },
  
   async createDiscussionThread(req, res) {
-    const [code, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.shortname }, perms.READ);
+    const [code, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.universeShortname }, perms.READ);
     if (!universe) return res.status(code);
     if (!universe.discussion_enabled) return res.status(403);
     if (!universe.discussion_open && universe.author_permissions[req.session.user.id] < perms.COMMENT) return res.status(403);
@@ -70,7 +78,7 @@ module.exports = {
   },
   
   async discussionThread(req, res) {
-    const [code1, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.shortname });
+    const [code1, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.universeShortname });
     res.status(code1);
     if (code1 !== 200) return;
     const [code2, threads] = await api.discussion.getThreads(req.session.user, {
@@ -99,8 +107,8 @@ module.exports = {
   },
 
   async itemList(req, res) {
-    const [code1, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.shortname });
-    const [code2, items] = await api.item.getByUniverseShortname(req.session.user, req.params.shortname, perms.READ, {
+    const [code1, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.universeShortname });
+    const [code2, items] = await api.item.getByUniverseShortname(req.session.user, req.params.universeShortname, perms.READ, {
       sort: req.query.sort,
       sortDesc: req.query.sort_order === 'desc',
       limit: req.query.limit,
@@ -119,10 +127,10 @@ module.exports = {
   },
 
   async editPerms(req, res) {
-    const [code1, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.shortname }, perms.ADMIN);
+    const [code1, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.universeShortname }, perms.ADMIN);
     const [code2, users] = await api.user.getMany();
     const [code3, contacts] = await api.contact.getAll(req.session.user, false);
-    const [code4, requests] = await api.universe.getAccessRequests(req.session.user, req.params.shortname);
+    const [code4, requests] = await api.universe.getAccessRequests(req.session.user, req.params.universeShortname);
     const code = code1 !== 200 ? code1 : (code2 !== 200 ? code2 : (code3 !== 200 ? code3 : code4));
     res.status(code);
     if (code !== 200) return;


### PR DESCRIPTION
closes #117, progress on #115

- Add home page, a piece of markdown text that will be rendered in a "Home" tab on the universe page if present.
- Add a public page, similar to the home page but is displayed instead of the "Access Denied" page if present.
- Add easyMDE fields in the universe editor for both these pages.
- If you try to access a page (for example `/items`) in a universe that you do not have access to, you will first be redirected to the universe main page under the hood before the server actually decides whether or not to send you to the login page. This is in case you either are logged in and should see the request access page, or are not logged in but the universe has a public page you should be shown.
- Fix some old CSS issues on mobile.