### PR TITLE
Improvements to lists and search page

### DIFF
--- a/api/models/item.js
+++ b/api/models/item.js
@@ -184,65 +184,35 @@ async function getMany(user, conditions, permissionsRequired=perms.READ, options
       ...(options.join ?? []),
     ];
 
-    let data;
     if (options.search) {
-      const query = new QueryBuilder().union(
-        getQuery(
-          selects,
-          permsCond,
-          whereConds.and('item.title LIKE ?', `%${options.search}%`),
-          options,
-        )
-      ).union(
-        getQuery(
-          selects,
-          permsCond,
-          whereConds.and('item.shortname LIKE ?', `%${options.search}%`),
-          options,
-        )
-      ).union(
-        getQuery(
-          selects,
-          permsCond,
-          whereConds.and('search_tag.tag = ?', options.search),
-          options,
-        ).innerJoin(['tag', 'search_tag'], new Cond('search_tag.item_id = item.id'))
-      ).union(
-        getQuery(
-          selects,
-          permsCond,
-          whereConds.and('search_tag.tag LIKE ?', `%${options.search}%`),
-          options,
-        ).innerJoin(['tag', 'search_tag'], new Cond('search_tag.item_id = item.id'))
-      );
-      data = await query.execute();
-      data = [
-        ...data,
-        ...(await getQuery(
-          [
-            ...selects,
-            [`LOCATE(?, JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body'))) AS match_pos`, null, options.search],
-            [`
-              SUBSTRING(
-                JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body')),
-                GREATEST(1, LOCATE(?, JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body'))) - 50),
-                100
-              ) AS snippet`,
-              null, options.search,
-            ],
-          ],
-          permsCond,
-          whereConds.and(`JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body')) LIKE ?`, `%${options.search}%`),
-          options,
-        ).execute()),
-      ]
-    } else {
-      const query = getQuery(selects, permsCond, whereConds, options);
-      for (const join of joins) {
-        query.join(...join);
-      }
-      data = await query.execute();
+      const searchCond = new Cond('item.title LIKE ?', `%${options.search}%`)
+        .or('item.shortname LIKE ?', `%${options.search}%`)
+        .or('search_tag.tag = ?', options.search)
+        .or('search_tag.tag LIKE ?', `%${options.search}%`)
+        .or(`JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body')) LIKE ?`, `%${options.search}%`);
+      whereConds = whereConds.and(searchCond);
+      selects.push([`LOCATE(?, JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body'))) AS match_pos`, null, options.search]);
+      selects.push([`
+        CASE
+          WHEN LOCATE(?, JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body'))) > 0
+          THEN SUBSTRING(
+            JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body')),
+            GREATEST(1, LOCATE(?, JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body'))) - 50),
+            100
+          )
+          ELSE NULL
+        END AS snippet`,
+        null, [options.search, options.search],
+      ]);
     }
+    const query = getQuery(selects, permsCond, whereConds, options);
+    for (const join of joins) {
+      query.join(...join);
+    }
+    if (options.search) {
+      query.innerJoin(['tag', 'search_tag'], new Cond('search_tag.item_id = item.id'));
+    }
+    const data = await query.execute();
 
     return [200, data];
   } catch (err) {

--- a/api/models/item.js
+++ b/api/models/item.js
@@ -208,15 +208,28 @@ async function getMany(user, conditions, permissionsRequired=perms.READ, options
           whereConds.and('search_tag.tag LIKE ?', `%${options.search}%`),
           options,
         ).innerJoin(['tag', 'search_tag'], new Cond('search_tag.item_id = item.id'))
-      ).union(
-        getQuery(
-          selects,
-          permsCond,
-          whereConds.and('item.obj_data LIKE ?', `%${options.search}%`),
-          options,
-        )
       );
       data = await query.execute();
+      data = [
+        ...data,
+        ...(await getQuery(
+          [
+            ...selects,
+            ['LOCATE(?, item.obj_data) AS match_pos', null, options.search],
+            [`
+              SUBSTRING(
+                JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body')),
+                GREATEST(1, LOCATE(?, JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body'))) - 50),
+                100
+              ) AS snippet`,
+              null, options.search,
+            ],
+          ],
+          permsCond,
+          whereConds.and('item.obj_data LIKE ?', `%"body":%"%${options.search}%"%`),
+          options,
+        ).execute()),
+      ]
     } else {
       const query = getQuery(selects, permsCond, whereConds, options);
       for (const join of joins) {

--- a/api/models/item.js
+++ b/api/models/item.js
@@ -215,7 +215,7 @@ async function getMany(user, conditions, permissionsRequired=perms.READ, options
         ...(await getQuery(
           [
             ...selects,
-            ['LOCATE(?, item.obj_data) AS match_pos', null, options.search],
+            [`LOCATE(?, JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body'))) AS match_pos`, null, options.search],
             [`
               SUBSTRING(
                 JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body')),

--- a/api/models/item.js
+++ b/api/models/item.js
@@ -226,7 +226,7 @@ async function getMany(user, conditions, permissionsRequired=perms.READ, options
             ],
           ],
           permsCond,
-          whereConds.and('item.obj_data LIKE ?', `%"body":%"%${options.search}%"%`),
+          whereConds.and(`JSON_UNQUOTE(JSON_EXTRACT(item.obj_data, '$.body')) LIKE ?`, `%${options.search}%`),
           options,
         ).execute()),
       ]

--- a/api/models/item.js
+++ b/api/models/item.js
@@ -115,8 +115,14 @@ function getQuery(selects=[], permsCond=undefined, whereConds=undefined, options
     ) tag`, new Cond('tag.item_id = item.id'))
     .where(whereConds)
     .groupBy(['item.id', 'user.username', 'universe.title', ...(options.groupBy ?? [])]);
-  if (options.sort) query.orderBy(options.sort, options.sortDesc);
-  if (options.limit) query.limit(options.limit);
+  if (options.sort) {
+    query.orderBy(options.sort, options.sortDesc);
+  } else {
+    query.orderBy('updated_at', true);
+  }
+  if (options.limit) {
+    query.limit(options.limit);
+  }
 
   return query;
 }

--- a/api/models/note.js
+++ b/api/models/note.js
@@ -43,12 +43,12 @@ async function getMany(user, conditions, options) {
       parsedConds.strings.push('note.public');
     }
     if (options?.search) {
-      parsedConds.strings.push('note.title LIKE ? OR note.body LIKE ? OR tag.tags LIKE ?');
+      parsedConds.strings.push('(note.title LIKE ? OR note.body LIKE ? OR tag.tags LIKE ?)');
       parsedConds.values.push(`%${options?.search}%`);
       parsedConds.values.push(`%${options?.search}%`);
       parsedConds.values.push(`%${options?.search}%`);
-      parsedConds.values.push(`%${options?.search}%`);
-      parsedConds.values.push(`%${options?.search}%`);
+      parsedConds.values.unshift(`%${options?.search}%`);
+      parsedConds.values.unshift(`%${options?.search}%`);
     }
     const queryString = `
       SELECT DISTINCT

--- a/api/models/note.js
+++ b/api/models/note.js
@@ -42,6 +42,14 @@ async function getMany(user, conditions, options) {
     } else {
       parsedConds.strings.push('note.public');
     }
+    if (options?.search) {
+      parsedConds.strings.push('note.title LIKE ? OR note.body LIKE ? OR tag.tags LIKE ?');
+      parsedConds.values.push(`%${options?.search}%`);
+      parsedConds.values.push(`%${options?.search}%`);
+      parsedConds.values.push(`%${options?.search}%`);
+      parsedConds.values.push(`%${options?.search}%`);
+      parsedConds.values.push(`%${options?.search}%`);
+    }
     const queryString = `
       SELECT DISTINCT
         note.id, note.uuid, note.title,
@@ -51,6 +59,8 @@ async function getMany(user, conditions, options) {
         ${options?.fullBody ? 'note.body' : 'SUBSTRING(note.body, 1, 255) AS body'}
         ${options?.connections ? ', item.items' : ''}
         ${options?.connections ? ', board.boards' : ''}
+        ${options?.search ? ', LOCATE(?, note.body) AS match_pos' : ''}
+        ${options?.search ? ', SUBSTRING(note.body,  GREATEST(1, LOCATE(?, note.body) - 50), 100) AS snippet' : ''}
       FROM note
         ${options?.connections ? `LEFT JOIN (
           SELECT itemnote.note_id, JSON_ARRAYAGG(JSON_ARRAY(item.title, item.shortname, iu.title, iu.shortname)) as items

--- a/api/models/universe.js
+++ b/api/models/universe.js
@@ -49,7 +49,8 @@ async function getMany(user, conditions, permissionLevel=perms.READ) {
       LEFT JOIN followeruniverse AS fu ON universe.id = fu.universe_id
       INNER JOIN user AS owner ON universe.author_id = owner.id
       ${conditionString}
-      GROUP BY universe.id;`;
+      GROUP BY universe.id
+      ORDER BY updated_at DESC;`;
     const data = await executeQuery(queryString, conditions && conditions.values);
     return [200, data];
   } catch (err) {

--- a/api/utils.js
+++ b/api/utils.js
@@ -26,6 +26,7 @@ class QueryBuilder {
    constructor() {
     this.table = null;
     this.selects = {};
+    this.selectValues = {};
     this.joins = [];
     this.whereCond = null;
     this.groups = {};
@@ -35,12 +36,16 @@ class QueryBuilder {
     this.unions = [];
    }
 
-   select(col, selectAs=null) {
-    if (col instanceof Array) col.forEach(args => {
-      if (args instanceof Array) this.select(...args);
-      else this.select(args);
-    });
-    else this.selects[col] = selectAs;
+   select(col, selectAs=null, value=null) {
+    if (col instanceof Array) {
+      col.forEach(args => {
+        if (args instanceof Array) this.select(...args);
+        else this.select(args);
+      });
+    } else {
+      this.selects[col] = selectAs;
+      this.selectValues[col] = value;
+    }
     return this;
    }
 
@@ -97,6 +102,7 @@ class QueryBuilder {
     if (selectCols.length) {
       if (!this.table) throw 'No table specified!';
       queryStr += `SELECT ${selectCols.map(col => {
+        if (this.selectValues[col]) values = [...values, this.selectValues[col]];
         if (this.selects[col]) return `${col} AS ${this.selects[col]}`;
         else return col;
       }).join(', ')}`;

--- a/api/utils.js
+++ b/api/utils.js
@@ -102,7 +102,10 @@ class QueryBuilder {
     if (selectCols.length) {
       if (!this.table) throw 'No table specified!';
       queryStr += `SELECT ${selectCols.map(col => {
-        if (this.selectValues[col]) values = [...values, this.selectValues[col]];
+        if (this.selectValues[col]) {
+          if (this.selectValues[col] instanceof Array) values = [...values, ...this.selectValues[col]];
+          else values = [...values, this.selectValues[col]];
+        }
         if (this.selects[col]) return `${col} AS ${this.selects[col]}`;
         else return col;
       }).join(', ')}`;

--- a/static/scripts/cardUtils.js
+++ b/static/scripts/cardUtils.js
@@ -5,7 +5,6 @@
 
   window.addEventListener('load', () => {
     document.querySelectorAll('.card-list .card[data-goto]').forEach(el => {
-      console.log(el, el.dataset.goto)
       el.addEventListener('click', () => {
         goTo(el.dataset.goto);
       });

--- a/static/scripts/listUtils.js
+++ b/static/scripts/listUtils.js
@@ -13,7 +13,6 @@ window.addEventListener('load', () => {
   document.querySelectorAll('.filter').forEach((filter) => {
     filter.onclick = (e) => {
       e.stopPropagation();
-      console.log(filter.dataset)
       toggleFilter(filter.dataset.filterKey, filter.dataset.filterValue);
     };
   });

--- a/templates/components/itemList.pug
+++ b/templates/components/itemList.pug
@@ -36,3 +36,10 @@
           each itemTag in item.tags
             if itemTag
               a.filter.link.link-animated( class={ 'link-selected': itemTag == tag } data-filter-key='tag' data-filter-value=itemTag ) ##{itemTag} 
+
+      if item.snippet && search
+        .row-2( style={ 'grid-column': '1 / 3' } )
+          small
+            i
+              - const snippet = item.snippet
+              +highlight(formatSnippet(snippet, item.match_pos >= 50, snippet.length === 100), search)

--- a/templates/components/notes.pug
+++ b/templates/components/notes.pug
@@ -52,6 +52,7 @@ block append styles
 
   div
     #note-list.card-list
+      input( id='search' name='search' placeholder='Search...' )
       each note in notes
         .sheet.card.d-flex.flex-col.gap-1( data-uuid=note.uuid data-note=note )
           h2.ma-0 #{note.title}
@@ -132,6 +133,7 @@ block append styles
       let noteState = 'list';
       const leftBtn = document.querySelector('#notes-left-btn');
       const noteList = document.querySelector('#note-list');
+      const searchBar = noteList.querySelector('#search');
       const noteEdit = document.querySelector('#note-edit');
       const noteDisplay = document.querySelector('#note-display');
       const noteLoading = document.querySelector('#note-loading');
@@ -376,6 +378,13 @@ block append styles
         if (noteState === 'loading') return;
         else if (noteState === 'list') createNote();
         else backToList();
+      });
+
+      searchBar.addEventListener('change', () => {
+        noteList.querySelectorAll('.card').forEach((el) => {
+          const { title, body } = JSON.parse(el.dataset.note);
+          el.classList.toggle('hidden', title.indexOf(searchBar.value) === -1 && body.indexOf(searchBar.value) === -1);
+        });
       });
 
       editTab.addEventListener('click', editNote);

--- a/templates/components/universeList.pug
+++ b/templates/components/universeList.pug
@@ -1,29 +1,38 @@
-.card-list
-  each universe in universes
-    .card.sheet.gap-4.align-start( data-goto=`${universeLink(universe.shortname)}/` )
-      .d-flex.flex-col.grow-1
-        h3.ma-0
-          a.link.link-animated( href=`${universeLink(universe.shortname)}/` ) #{universe.title}
-        .d-flex.gap-1
+mixin universeCard(universe)
+  .card.sheet.gap-4.align-start( data-goto=`${universeLink(universe.shortname)}/` )
+    .d-flex.flex-col.grow-1
+      h3.ma-0
+        a.link.link-animated( href=`${universeLink(universe.shortname)}/` ) #{universe.title}
+      .d-flex.gap-1
 
-      .d-flex.flex-col.grow-3( style='grid-column: 2 / 4;' )
+    .d-flex.flex-col.grow-3( style='grid-column: 2 / 4;' )
+      span 
+        b #{T('Authors')}: 
+        +authorList(universe.authors, universe.author_permissions)
+      .d-flex.gap-2.flex-wrap
+        span
+          b #{T('Created')}: 
+          | #{formatDate(universe.created_at, true)}
+        | — 
         span 
-          b #{T('Authors')}: 
-          +authorList(universe.authors, universe.author_permissions)
-        .d-flex.gap-2.flex-wrap
-          span
-            b #{T('Created')}: 
-            | #{formatDate(universe.created_at, true)}
-          | — 
-          span 
-            b #{T('Updated')}: 
-            | #{formatDate(universe.updated_at, true)}
+          b #{T('Updated')}: 
+          | #{formatDate(universe.updated_at, true)}
+        | —
+        span #{universe.public ? 'Public' : 'Private'}
+        if contextUser
           | —
-          span #{universe.public ? 'Public' : 'Private'}
-          if contextUser
-            | —
-            a.follow-btn.link.link-animated( data-following=universe.followers[contextUser.id] data-universe-short=universe.shortname )
-              | #{universe.followers[contextUser.id] ? 'Unfollow' : 'Follow'}
+          a.follow-btn.link.link-animated( data-following=universe.followers[contextUser.id] data-universe-short=universe.shortname )
+            | #{universe.followers[contextUser.id] ? 'Unfollow' : 'Follow'}
+
+.card-list
+  if contextUser
+    each universe in universes.filter(universe => (universe.followers[contextUser.id] || universe.author_permissions[contextUser.id] >= perms.WRITE))
+      +universeCard(universe)
+    each universe in universes.filter(universe => !(universe.followers[contextUser.id] || universe.author_permissions[contextUser.id] >= perms.WRITE))
+      +universeCard(universe)
+  else
+    each universe in universes
+      +universeCard(universe)
   
   script.
     document.querySelectorAll('.follow-btn').forEach((followBtn) => {

--- a/templates/edit/settings.pug
+++ b/templates/edit/settings.pug
@@ -55,7 +55,6 @@ block content
           } else if (response.status === 200) {
             window.location.reload();
           } else {
-            console.log(data)
             formError.innerText = data;
             formError.classList.remove('hidden');
           }

--- a/templates/helpers.pug
+++ b/templates/helpers.pug
@@ -7,6 +7,23 @@
     }
     return prefixedItems;
   };
+  const formatSnippet = (snippet, cutStart=true, cutEnd=true) => {
+    let clean = snippet.trim();
+
+    const firstSpace = clean.indexOf(' ');
+    if (cutStart && firstSpace > 0 && firstSpace < Math.min(15, clean.length - 15)) {
+      clean = clean.slice(firstSpace + 1);
+    }
+
+    const lastSpace = clean.lastIndexOf(' ');
+    if (cutEnd && lastSpace > clean.length - 15 && clean.length > 30) {
+      clean = clean.slice(0, lastSpace);
+    }
+
+    clean = clean.trim();
+
+    return `${cutStart ? '...' : ''}${clean}${cutEnd ? '...' : ''}`;
+  };
   const formatDate = (date, intervalOnly=false, short=false) => {
     if (!date) return;
     const now = new Date();

--- a/templates/layout.pug
+++ b/templates/layout.pug
@@ -46,7 +46,6 @@ html(lang='en')
       }
       function universeLink(uniShort) {
         const displayUniverse = '#{displayUniverse}';
-        console.log(displayUniverse)
         if (displayUniverse) {
           if (displayUniverse === uniShort) return '#{ADDR_PREFIX}';
           else return `https://#{DOMAIN}#{ADDR_PREFIX}/universes/${uniShort}`;

--- a/templates/list/items.pug
+++ b/templates/list/items.pug
@@ -11,33 +11,13 @@ block content
     label( for='sort' )
       b #{T('Sort by')}: 
     select( id='sort' name='sort' )
-      option( value='created_at' ) Created
       option( value='updated_at' ) Updated
+      option( value='created_at' ) Created
       option( value='item_type' ) Type
       option( value='title' ) Title
       option( value='author' ) Author
     select( id='sort_order' name='sort_order' )
-      option( value='asc' ) Ascending
       option( value='desc' ) Descending
+      option( value='asc' ) Ascending
   hr
   include ../components/itemList.pug
-  //- table.sheet.w-100
-  //-   thead
-  //-     th Name
-  //-     th Type
-  //-     th Universe
-  //-     th Author
-  //-     th Created
-  //-     th Updated
-  //-   tbody
-  //-     each item in items
-  //-       tr
-  //-         td
-  //-           a.link.link-animated( href=`${ADDR_PREFIX}/items/${item.shortname}` ) #{item.title}
-  //-         td #{capitalize(item.itemTypeName)}
-  //-         td
-  //-           a.link.link-animated( href=`${ADDR_PREFIX}/universes/${item.universe_short}` ) #{item.universe}
-  //-         td
-  //-           a.link.link-animated( href=`${ADDR_PREFIX}/users/${item.author}` ) #{item.author}
-  //-         td #{formatDate(item.created_at, true)}
-  //-         td #{formatDate(item.updated_at, true)}

--- a/templates/list/items.pug
+++ b/templates/list/items.pug
@@ -1,4 +1,5 @@
 extends ../layout.pug
+include ../mixins.pug
 
 block scripts
   script
@@ -7,8 +8,8 @@ block scripts
 
 block content
   h1.center Items
-  div
-    label( for='sort' )
+  .d-flex.align-center
+    label.mr-1( for='sort' )
       b #{T('Sort by')}: 
     select( id='sort' name='sort' )
       option( value='updated_at' ) Updated
@@ -19,5 +20,9 @@ block content
     select( id='sort_order' name='sort_order' )
       option( value='desc' ) Descending
       option( value='asc' ) Ascending
+    .grow-1
+    form.flex-row.gap-0
+      input( id='search' name='search' value=search placeholder='Search...' )
+      button( type='submit' ) &#x1F50E;&#xFE0E;
   hr
   include ../components/itemList.pug

--- a/templates/list/search.pug
+++ b/templates/list/search.pug
@@ -25,7 +25,8 @@ block content
       .card.sheet.gap-4.align-start( data-goto=`${universeLink(universe.shortname)}/` )
         .d-flex.flex-col.grow-1
           h3.ma-0
-            a.link.link-animated( href=`${universeLink(universe.shortname)}/` ) #{universe.title}
+            a.link.link-animated( href=`${universeLink(universe.shortname)}/` )
+              +highlight(universe.title, search, true)
           .d-flex.gap-1
 
         .d-flex.flex-col.grow-3
@@ -78,3 +79,33 @@ block content
               i
                 - const snippet = item.snippet
                 +highlight(formatSnippet(snippet, item.match_pos >= 50, snippet.length === 100), search)
+    each note in notes
+      .card.sheet.gap-4.align-start( data-goto=`/notes/${note.uuid}` )
+        .d-flex.flex-col.grow-1
+          h3.ma-0
+            a.link.link-animated( href=`/notes/${note.uuid}` )
+              +highlight(note.title, search, true)
+
+        .d-flex.flex-col.grow-3
+            span 
+              b #{T('Created')}: 
+              | #{formatDate(note.created_at)}
+            span 
+              b #{T('Updated')}: 
+              | #{formatDate(note.updated_at)}
+
+        .d-flex.flex-wrap.gap-1.grow-4
+          if note.tags
+            each noteTag in note.tags
+              if noteTag === search
+                b ##{noteTag} 
+              else
+                span #
+                  +highlight(noteTag, search)
+        
+        if note.snippet
+          .row-2( style={ 'grid-column': '1 / 3' } )
+            small
+              i
+                - const snippet = note.snippet
+                +highlight(formatSnippet(snippet, note.match_pos >= 50, snippet.length === 100), search)

--- a/templates/list/search.pug
+++ b/templates/list/search.pug
@@ -13,7 +13,7 @@ block content
 
   script.
   h1.center Search
-  form.flex-row.gap-0
+  form.flex-row.gap-0.justify-end
     input( id='search' name='search' value=search placeholder='Search...' )
     button( type='submit' ) &#x1F50E;&#xFE0E;
   hr

--- a/templates/list/search.pug
+++ b/templates/list/search.pug
@@ -14,7 +14,7 @@ block content
   script.
   h1.center Search
   form.flex-row.gap-0
-    input( id='search', name='search', value=search )
+    input( id='search' name='search' value=search placeholder='Search...' )
     button( type='submit' ) &#x1F50E;&#xFE0E;
   hr
   if search

--- a/templates/list/search.pug
+++ b/templates/list/search.pug
@@ -53,7 +53,8 @@ block content
       .card.sheet.gap-4.align-start( data-goto=`${universeLink(item.universe_short)}/items/${item.shortname}` )
         .d-flex.flex-col.grow-1
           h3.ma-0
-            a.link.link-animated( href=`${universeLink(item.universe_short)}/items/${item.shortname}` ) #{item.title}
+            a.link.link-animated( href=`${universeLink(item.universe_short)}/items/${item.shortname}` )
+              +highlight(item.title, search, true)
           span #{capitalize(item.item_type)}
           div
             a.link.link-animated( href=`${universeLink(item.universe_short)}/` ) #{item.universe}
@@ -72,4 +73,15 @@ block content
         .d-flex.flex-wrap.gap-1.grow-4
           if item.tags
             each itemTag in item.tags
-              span ##{itemTag} 
+              if itemTag === search
+                b ##{itemTag} 
+              else
+                span #
+                  +highlight(itemTag, search)
+        
+        if item.snippet
+          .row-2( style={ 'grid-column': '1 / 3' } )
+            small
+              i
+                - const snippet = item.snippet
+                +highlight(formatSnippet(snippet, item.match_pos >= 50, snippet.length === 100), search)

--- a/templates/list/search.pug
+++ b/templates/list/search.pug
@@ -12,17 +12,10 @@ block content
     include /static/scripts/listUtils.js
 
   script.
-    function search() {
-      const url = new URL(window.location);
-      url.searchParams.set('search', document.getElementById('search').value);
-      history.pushState(null, '', url);
-      location.reload();
-    }
-
   h1.center Search
-  div
+  form.flex-row.gap-0
     input( id='search', name='search', value=search )
-    button( onclick='search()' ) &#x1F50E;&#xFE0E;
+    button( type='submit' ) &#x1F50E;&#xFE0E;
   hr
   if search
     p

--- a/templates/list/universeItems.pug
+++ b/templates/list/universeItems.pug
@@ -24,13 +24,13 @@ block content
     label( for='sort' )
       b #{T('Sort by')}: 
     select( id='sort' name='sort' )
-      option( value='created_at' ) Created
       option( value='updated_at' ) Updated
+      option( value='created_at' ) Created
       option( value='item_type' ) Type
       option( value='title' ) Title
       option( value='author' ) Author
     select( id='sort_order' name='sort_order' )
-      option( value='asc' ) Ascending
       option( value='desc' ) Descending
+      option( value='asc' ) Ascending
   hr
   include ../components/itemList.pug

--- a/templates/list/universeItems.pug
+++ b/templates/list/universeItems.pug
@@ -1,4 +1,5 @@
 extends ../layout.pug
+include ../mixins.pug
 
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
@@ -20,8 +21,8 @@ block content
     else
       | Items 
     | of #{universe.title}
-  div
-    label( for='sort' )
+  .d-flex.align-center
+    label.mr-1( for='sort' )
       b #{T('Sort by')}: 
     select( id='sort' name='sort' )
       option( value='updated_at' ) Updated
@@ -32,5 +33,9 @@ block content
     select( id='sort_order' name='sort_order' )
       option( value='desc' ) Descending
       option( value='asc' ) Ascending
+    .grow-1
+    form.flex-row.gap-0
+      input( id='search' name='search' value=search placeholder='Search...' )
+      button( type='submit' ) &#x1F50E;&#xFE0E;
   hr
   include ../components/itemList.pug

--- a/templates/list/universes.pug
+++ b/templates/list/universes.pug
@@ -12,6 +12,11 @@ block content
     include /static/scripts/fetchUtils.js
   
   h1.center Universes
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes/create` ) Create New
+  .d-flex.align-end
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes/create` ) Create New
+    .grow-1
+    form.flex-row.gap-0
+      input( id='search' name='search' value=search placeholder='Search...' )
+      button( type='submit' ) &#x1F50E;&#xFE0E;
   hr
   include ../components/universeList.pug

--- a/templates/mixins.pug
+++ b/templates/mixins.pug
@@ -12,3 +12,17 @@ mixin authorList(authors, author_permissions)
       a.link.link-animated( href=`${ADDR_PREFIX}/users/${author}` )= author
       | #{suff}
       - i++;
+
+mixin highlight(string, keyword, italics)
+  -
+    const regex = new RegExp(`(${keyword})`, 'gi');
+    const segments = string.split(regex);
+  span
+    each segment, idx in segments
+      if segment.toLowerCase() === keyword.toLowerCase()
+        if italics
+          i #{segment}
+        else
+          b #{segment}
+      else
+        | #{segment}

--- a/templates/verify.pug
+++ b/templates/verify.pug
@@ -9,12 +9,10 @@ block scripts
     async function sendVerifyLink() {
       clearInterval(updateRetryAfterInterval);
       const [response, data] = await getJSON('#{ADDR_PREFIX}/api/users/#{user.username}/send-verify-link');
-      console.log(response)
       const retryAfterText = document.querySelector('#retry-after');
       if (response.status === 429) {
         const retryAfter = new Date(data);
         const secondsLeft = Math.round((retryAfter - new Date()) / 1000);
-        console.log(retryAfter, secondsLeft)
         retryAfterText.textContent = `Please wait ${secondsLeft} seconds before trying again.`;
         updateRetryAfterInterval = setInterval(() => {
           const secondsLeft = Math.round((retryAfter - new Date()) / 1000);

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -184,7 +184,6 @@ block content
           const hash = location.hash.substr(1);
           if (hash) {
             const el = document.getElementById(hash);
-            console.log(hash, el)
             el.scrollIntoView();
           }
         });
@@ -217,7 +216,6 @@ block content
           e.stopPropagation();
           if (!galleryModalState[i]) {
             itemKey.classList.add('modal');
-            console.log(itemKey)
             galleryModalState[i] = true;
           }
         };

--- a/views/pages/item.js
+++ b/views/pages/item.js
@@ -9,6 +9,7 @@ const logger = require('../../logger');
 
 module.exports = {
   async list(req, res) {
+    const search = req.query.search;
     const [code1, universes] = await api.universe.getMany(req.session.user);
     const [code2, items] = await api.item.getMany(req.session.user, null, Math.max(perms.READ, Number(req.query.perms)) || perms.READ, {
       sort: req.query.sort,
@@ -18,6 +19,7 @@ module.exports = {
       tag: req.query.tag,
       universe: req.query.universe,
       author: req.query.author,
+      search,
     });
     const code = code1 !== 200 ? code1 : code2;
     res.status(code);
@@ -33,6 +35,7 @@ module.exports = {
       universe: req.query.universe,
       author: req.query.author,
       showUniverse: true,
+      search,
     });
   },
 

--- a/views/pages/misc.js
+++ b/views/pages/misc.js
@@ -44,25 +44,16 @@ module.exports = {
       const [code1, universes] = await api.universe.getMany(req.session.user, { strings: ['title LIKE ?'], values: [`%${search}%`] });
       res.status(code1);
       if (!universes) return;
-      const [code2, itemsRaw] = await api.item.getMany(req.session.user, null, perms.READ, { search });
+      const [code2, items] = await api.item.getMany(req.session.user, null, perms.READ, { search });
       res.status(code2);
-      if (!itemsRaw) return;
+      if (!items) return;
       let notes, code3;
       if (req.session.user) {
         [code3, notes] = await api.note.getByUsername(req.session.user, req.session.user.username, null, { search });
         res.status(code3);
         if (!notes) return;
       }
-      const matchedItems = {};
-      for (const item of itemsRaw) {
-        if (item.id in matchedItems) {
-          matchedItems[item.id] = {...item, ...matchedItems[item.id]};
-        } else {
-          matchedItems[item.id] = item;
-        }
-      }
-      const items = Object.values(matchedItems).sort((a, b) => a.updated_at < b.updated_at ? 1 : -1);
-      res.prepareRender('search', {items, universes, notes: notes ?? [], search });
+      res.prepareRender('search', { items, universes, notes: notes ?? [], search });
     } else {
       res.prepareRender('search', { items: [], universes: [], notes: [], search: '' });
     }

--- a/views/pages/misc.js
+++ b/views/pages/misc.js
@@ -42,14 +42,17 @@ module.exports = {
     const search = req.query.search;
     if (search) {
       const [code1, universes] = await api.universe.getMany(req.session.user, { strings: ['title LIKE ?'], values: [`%${search}%`] });
+      res.status(code1);
+      if (!universes) return;
       const [code2, itemsRaw] = await api.item.getMany(req.session.user, null, perms.READ, { search });
+      res.status(code2);
+      if (!itemsRaw) return;
       let notes, code3;
       if (req.session.user) {
         [code3, notes] = await api.note.getByUsername(req.session.user, req.session.user.username, null, { search });
+        res.status(code3);
+        if (!notes) return;
       }
-      const code = code1 !== 200 ? code1 : code2 !== 200 ? code2 : code3;
-      res.status(code);
-      if (code !== 200) return;
       const matchedItems = {};
       for (const item of itemsRaw) {
         if (item.id in matchedItems) {

--- a/views/pages/misc.js
+++ b/views/pages/misc.js
@@ -43,7 +43,11 @@ module.exports = {
     if (search) {
       const [code1, universes] = await api.universe.getMany(req.session.user, { strings: ['title LIKE ?'], values: [`%${search}%`] });
       const [code2, itemsRaw] = await api.item.getMany(req.session.user, null, perms.READ, { search });
-      const code = code1 !== 200 ? code1 : code2;
+      let notes, code3;
+      if (req.session.user) {
+        [code3, notes] = await api.note.getByUsername(req.session.user, req.session.user.username, null, { search });
+      }
+      const code = code1 !== 200 ? code1 : code2 !== 200 ? code2 : code3;
       res.status(code);
       if (code !== 200) return;
       const matchedItems = {};
@@ -55,9 +59,9 @@ module.exports = {
         }
       }
       const items = Object.values(matchedItems).sort((a, b) => a.updated_at < b.updated_at ? 1 : -1);
-      res.prepareRender('search', {items, universes, search });
+      res.prepareRender('search', {items, universes, notes: notes ?? [], search });
     } else {
-      res.prepareRender('search', { items: [], universes: [], search: '' });
+      res.prepareRender('search', { items: [], universes: [], notes: [], search: '' });
     }
   },
 };

--- a/views/pages/universe.js
+++ b/views/pages/universe.js
@@ -9,10 +9,11 @@ const logger = require('../../logger');
 
 module.exports = {
   async list(req, res) {
-    const [code, universes] = await api.universe.getMany(req.session.user);
+    const search = req.query.search;
+    const [code, universes] = await api.universe.getMany(req.session.user, search ? { strings: ['title LIKE ?'], values: [`%${search}%`] } : null);
     res.status(code);
     if (!universes) return;
-    res.prepareRender('universeList', { universes });
+    res.prepareRender('universeList', { universes, search });
   },
   
   async create(_, res) {
@@ -106,6 +107,7 @@ module.exports = {
   },
 
   async itemList(req, res) {
+    const search = req.query.search;
     const [code1, universe] = await api.universe.getOne(req.session.user, { shortname: req.params.universeShortname });
     const [code2, items] = await api.item.getByUniverseShortname(req.session.user, req.params.universeShortname, perms.READ, {
       sort: req.query.sort,
@@ -113,6 +115,7 @@ module.exports = {
       limit: req.query.limit,
       type: req.query.type,
       tag: req.query.tag,
+      search,
     });
     const code = code1 !== 200 ? code1 : code2;
     res.status(code);
@@ -122,6 +125,7 @@ module.exports = {
       universe,
       type: req.query.type,
       tag: req.query.tag,
+      search,
     });
   },
 


### PR DESCRIPTION
closes #88, closes #109, closes #110, closes #148, closes #98

- Fetch and show a preview of the item body when a match is found
- Highlight matches in items (except for shortname matches)
- Allow using enter to search on the search page
- Allow searching for notes on the search page
- Allow searching on the notes page (frontend search, only in title and the body preview)
- Set default sort order for items to Most Recently Updated
- Sort universes by Most Recently Updated, group by follow status and author status
- Items on search page are no longer grouped by the type of match
- Add search bars to item list pages
- Add search bar to universe list page

