### PR TITLE
Misc. UI Fixes

### DIFF
--- a/cypress/e2e/item_spec.cy.js
+++ b/cypress/e2e/item_spec.cy.js
@@ -113,7 +113,7 @@ describe('Item spec', () => {
 
     cy.get('.item-type a').contains('Characters').parent().parent().parent().find('.cardBtn').contains('New').click();-
 
-    cy.get('h2').contains('New Item for Public Test Universe').should('exist');
+    cy.get('h2').contains('New Character for Public Test Universe').should('exist');
 
     cy.get('#title').type('Cypress Character');
     cy.get('#shortname').should('have.value', 'cypress-character');

--- a/cypress/e2e/universe_spec.cy.js
+++ b/cypress/e2e/universe_spec.cy.js
@@ -96,7 +96,7 @@ describe('Universe spec', () => {
 
   it('creates new private universe', () => {
     cy.visit('/universes');
-    cy.get('a').contains('Create New').click();
+    cy.get('a').contains('New Universe').click();
 
     cy.get('h2').contains('New Universe').should('exist');
 

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -304,7 +304,7 @@ header {
   padding: 1.25rem;
   background-color: #fefefe;
   border-radius: 0.25rem;
-  box-shadow: silver 2px 2px 5px 0px;
+  box-shadow: silver 0.125rem 0.125rem 0.3125rem 0;
 }
 
 .itemTab {

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -952,6 +952,9 @@ input:checked + .slider:before {
   justify-content: space-between;
 }
 
+.grow-0 {
+  flex-grow: 0;
+}
 .grow-1 {
   flex-grow: 1;
 }
@@ -1132,6 +1135,9 @@ input:checked + .slider:before {
   padding-bottom: 1rem;
 }
 
+.pl-0 {
+  padding-left: 0;
+}
 .pl-1 {
   padding-left: 0.25rem;
 }
@@ -1139,6 +1145,9 @@ input:checked + .slider:before {
   padding-left: 0.5rem;
 }
 
+.pr-0 {
+  padding-right: 0;
+}
 .pr-1 {
   padding-right: 0.25rem;
 }

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -15,6 +15,10 @@ h1, h2, h3, h4, h5, h6, .lora {
   scroll-margin-top: var(--page-margin-top);
 }
 
+ul, ol {
+  padding-inline-start: 2.5rem;
+}
+
 body {
   min-height: 100vh;
   margin: 0;

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -232,10 +232,6 @@ header {
   flex-grow: 3;
 }
 
-.cardLink:hover {
-  color: #666;
-}
-
 .item-type .cardLink div {
   height: 100%;
   display: flex;

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -1080,6 +1080,9 @@ input:checked + .slider:before {
 .mt-4 {
   margin-top: 1rem;
 }
+.mt-8 {
+  margin-top: 2rem;
+}
 
 .pa-0 {
   padding: 0;
@@ -1089,6 +1092,27 @@ input:checked + .slider:before {
 }
 .pa-2 {
   padding: 0.5rem;
+}
+
+.px-1 {
+  padding-right: 0.25rem;
+  padding-left: 0.25rem;
+}
+.px-2 {
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+.px-3 {
+  padding-right: 0.75rem;
+  padding-left: 0.75rem;
+}
+.px-4 {
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+.px-8 {
+  padding-right: 2rem;
+  padding-left: 2rem;
 }
 
 .py-1 {

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -200,11 +200,13 @@ header {
 
 .card {
   box-shadow: 0 0.25rem 0.5rem 0 rgb(0 0 0 / 20%);
-  transition: box-shadow 0.3s;
+  transition: box-shadow 0.3s, top 0.2s;
   display: grid;
   grid-template-columns: inherit;
   grid-column: 1 / 4;
   border-radius: 0.25rem;
+  position: relative;
+  top: 0;
 }
 
 .card.item-type {
@@ -217,6 +219,7 @@ header {
 
 .card:hover {
   box-shadow: 0 0.5rem 1rem 0 rgb(0 0 0 / 30%);
+  top: -0.125rem;
 }
 
 .card.item-type div {

--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -2,14 +2,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
 
 :root {
-  --navbar-height: 51px;
+  --navbar-height: 3.1875rem;
   --page-margin-top: calc(var(--navbar-height) + 1rem);
-}
-
-@media only screen and (max-device-width: 480px) {
-  :root {
-    --navbar-height: 102px;
-  }
 }
 
 * {

--- a/templates/components/itemList.pug
+++ b/templates/components/itemList.pug
@@ -1,4 +1,14 @@
 .card-list
+  if universe
+    .card.sheet( data-goto=`${universeLink(universe.shortname)}/items/create${type ? `?type=${type}` : ''}` )
+      .d-flex.justify-center( style={ 'grid-column': '1 / 4' } )
+        a.link.d-flex.justify-center( href=`${universeLink(universe.shortname)}/items/create${type ? `?type=${type}` : ''}` )
+          .navbarText.material-symbols-outlined.heavy.ma-0.pa-1.pr-0.grow-0( style={ 'font-size': '1.5rem' } onclick="showModal('new-tab-modal')" ) add
+          .big-text.navbarText.pa-1.grow-0 New 
+            if type
+              | #{capitalize(T(`${((universe.obj_data.cats || {})[type] || [, 'Missing Category'])[0]}`))}
+            else
+              | Item
   each item in items
     .card.sheet.gap-4.align-start( data-goto=`${universeLink(item.universe_short)}/items/${item.shortname}` )
       .d-flex.flex-col.grow-1

--- a/templates/components/itemList.pug
+++ b/templates/components/itemList.pug
@@ -1,11 +1,11 @@
 .card-list
   if universe
-    .card.sheet( data-goto=`${universeLink(universe.shortname)}/items/create${type ? `?type=${type}` : ''}` )
+    .card.sheet( data-goto=`${universeLink(universe.shortname || universe)}/items/create${type ? `?type=${type}` : ''}` )
       .d-flex.justify-center( style={ 'grid-column': '1 / 4' } )
-        a.link.d-flex.justify-center( href=`${universeLink(universe.shortname)}/items/create${type ? `?type=${type}` : ''}` )
+        a.link.d-flex.justify-center( href=`${universeLink(universe.shortname || universe)}/items/create${type ? `?type=${type}` : ''}` )
           .navbarText.material-symbols-outlined.heavy.ma-0.pa-1.pr-0.grow-0( style={ 'font-size': '1.5rem' } onclick="showModal('new-tab-modal')" ) add
           .big-text.navbarText.pa-1.grow-0 New 
-            if type
+            if type && universe.obj_data
               | #{capitalize(T(`${((universe.obj_data.cats || {})[type] || [, 'Missing Category'])[0]}`))}
             else
               | Item

--- a/templates/components/universeList.pug
+++ b/templates/components/universeList.pug
@@ -25,6 +25,11 @@ mixin universeCard(universe)
             | #{universe.followers[contextUser.id] ? 'Unfollow' : 'Follow'}
 
 .card-list
+  .card.sheet( data-goto=`${ADDR_PREFIX}/universes/create` )
+    .d-flex.justify-center( style={ 'grid-column': '1 / 4' } )
+      a.link.d-flex.justify-center( href=`${ADDR_PREFIX}/universes/create` )
+        .navbarText.material-symbols-outlined.heavy.ma-0.pa-1.pr-0.grow-0( style={ 'font-size': '1.5rem' } onclick="showModal('new-tab-modal')" ) add
+        .big-text.navbarText.pa-1.grow-0 New Universe
   if contextUser
     each universe in universes.filter(universe => (universe.followers[contextUser.id] || universe.author_permissions[contextUser.id] >= perms.WRITE))
       +universeCard(universe)

--- a/templates/create/item.pug
+++ b/templates/create/item.pug
@@ -4,11 +4,14 @@ block title
   title New Item for #{universe.title}
 
 block breadcrumbs
-  a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
+  if displayUniverse
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{universe.title}
+  else
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
   |  / 
   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/items` ) #{T('Items')}
   |  / 

--- a/templates/create/item.pug
+++ b/templates/create/item.pug
@@ -11,9 +11,13 @@ block breadcrumbs
     |  / 
     a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
     |  / 
-    a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
+    a.link.link-animated#uni-breadcrumb( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
   |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/items` ) #{T('Items')}
+  a.link.link-animated#type-breadcrumb( href=`${ADDR_PREFIX}/universes/${universe.shortname}/items${item_type ? `?type=${item_type}` : ''}` )
+    if item_type
+      | #{capitalize(T(`${((universe.obj_data.cats || {})[item_type] || [, 'Missing Category'])[1]}`))}
+    else
+      | #{T('Items')}
   |  / 
   span #{T('New')}
 
@@ -36,6 +40,10 @@ block scripts
     window.addEventListener('load', () => {
       const titleInput = document.querySelector('#title');
       const shortnameInput = document.querySelector('#shortname');
+      const typeSelect = document.querySelector('#item_type');
+      const uniBreadcrumb = document.querySelector('#uni-breadcrumb');
+      const typeBreadcrumb = document.querySelector('#type-breadcrumb');
+      const typeHeaderSpan = document.querySelector('#type-header-span');
       let hasEditedShortname = !!shortnameInput.value;
 
       titleInput.addEventListener('input', () => {
@@ -46,10 +54,17 @@ block scripts
       shortnameInput.addEventListener('input', () => {
         hasEditedShortname = true;
       });
+      typeSelect.addEventListener('change', () => {
+        typeBreadcrumb.href = `${uniBreadcrumb.href}/items?type=${typeSelect.value}`;
+        typeBreadcrumb.textContent = typeSelect.selectedOptions[0].dataset.typePl;
+        typeHeaderSpan.textContent = typeSelect.selectedOptions[0].textContent;
+      });
     });
 
 block content
-  h2 New Item for #{universe.title}
+  h2 New 
+    span#type-header-span #{capitalize(T(`${((universe.obj_data.cats || {})[item_type] || [, 'Missing Category'])[0]}`))}
+    |  for #{universe.title}
   if universe.obj_data.cats
     form( method='POST' )
       div.inputGroup
@@ -62,7 +77,7 @@ block content
         label( for='item_type' ) Type: 
         select( id='item_type' name='item_type' )
           each type, shortname in universe.obj_data.cats
-              option( value=(shortname) selected=(item_type === shortname) )= capitalize(type[0])
+              option( value=(shortname) selected=(item_type === shortname) data-type-pl=capitalize(type[1]) )= capitalize(type[0])
       div
         input( type='hidden' name='obj_data' value='{}' )
         button( type='submit' ) Create Item

--- a/templates/create/item.pug
+++ b/templates/create/item.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title New Item for #{universe.title}
+
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
   |  / 

--- a/templates/create/universe.pug
+++ b/templates/create/universe.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title New Universe — Archivium
+
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
   |  / 

--- a/templates/create/universeThread.pug
+++ b/templates/create/universeThread.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title New Discussion for #{universe.title}
+
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
   |  / 

--- a/templates/create/universeThread.pug
+++ b/templates/create/universeThread.pug
@@ -4,11 +4,14 @@ block title
   title New Discussion for #{universe.title}
 
 block breadcrumbs
-  a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
+  if displayUniverse
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{universe.title}
+  else
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
   |  / 
   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}?tab=discuss` ) #{T('Discuss')}
   |  / 

--- a/templates/edit/forgotPassword.pug
+++ b/templates/edit/forgotPassword.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title Password Reset
+
 block scripts
   script( src='https://www.google.com/recaptcha/api.js' )
   script.

--- a/templates/edit/item.pug
+++ b/templates/edit/item.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title Edit #{item.title}
+
 block styles
   link( rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css" )
 

--- a/templates/edit/itemRaw.pug
+++ b/templates/edit/itemRaw.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title Edit #{item.title} (JSON Editor)
+
 block content
   script
     include /static/scripts/domUtils.js

--- a/templates/edit/resetPassword.pug
+++ b/templates/edit/resetPassword.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title Password Reset
+
 block content
   h2 Password Reset
   p 

--- a/templates/edit/settings.pug
+++ b/templates/edit/settings.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title Settings — Archivium
+
 block scripts
   script
     include /static/scripts/tabs.js

--- a/templates/edit/universe.pug
+++ b/templates/edit/universe.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title Edit #{universe.title}
+
 block append styles
   link( rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css" )
   style.

--- a/templates/edit/universePerms.pug
+++ b/templates/edit/universePerms.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title Permissions — #{universe.title}
+
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
   |  / 

--- a/templates/edit/universePerms.pug
+++ b/templates/edit/universePerms.pug
@@ -23,7 +23,9 @@ block content
       });
     });
 
-  h2 Update Permissions for #{universe.title}
+  .d-flex.justify-between.align-baseline
+    h2 Update Permissions for #{universe.title}
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) Go back
   .d-flex.flex-col.align-start
     .grid( style={ 'grid-template-columns': '1fr 1rem 1fr' } )
       each perm, aid in universe.author_permissions

--- a/templates/edit/universePerms.pug
+++ b/templates/edit/universePerms.pug
@@ -4,11 +4,14 @@ block title
   title Permissions — #{universe.title}
 
 block breadcrumbs
-  a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
+  if displayUniverse
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{universe.title}
+  else
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
   |  / 
   span #{T('Set Permissions')}
 

--- a/templates/error.pug
+++ b/templates/error.pug
@@ -1,5 +1,8 @@
 extends layout.pug
 
+block title
+  title Error #{code} — Archivium
+
 block content
   div
     div.error

--- a/templates/home.pug
+++ b/templates/home.pug
@@ -47,92 +47,93 @@ block content
         a.link.link-animated( href=`${ADDR_PREFIX}/universes/create` ) create a new universe 
         | to get started!
   else
-    .d-flex.gap-1.flex-wrap.align-start
-      .grow-1.d-flex.flex-col.gap-1
-        .sheet
-          h2 My Universes
-          table.w-100
-            thead
-              th Name
-              th Updated
-            tbody
-              each universe in universes
-                tr
-                  td
-                    a.link.link-animated( href=`${universeLink(universe.shortname)}` ) #{universe.title}
-                  td
-                    small #{formatDate(universe.updated_at, true)}
-        .sheet
-          h2 Universes I Follow
-          table.w-100
-            thead
-              th Name
-              th Updated
-            tbody
-              each universe in followedUniverses
-                tr
-                  td
-                    .d-flex.align-center.gap-1
-                      a.link.d-flex.align-center.unfollow-link( data-universe=universe.shortname )
-                        span.material-symbols-outlined( style={ 'font-size': '1rem' } ) cancel
+    .d-flex.flex-col
+      .d-flex.gap-1.flex-wrap.align-start.w-100
+        .grow-1.d-flex.flex-col.gap-1
+          .sheet
+            h2 My Universes
+            table.w-100
+              thead
+                th Name
+                th Updated
+              tbody
+                each universe in universes
+                  tr
+                    td
                       a.link.link-animated( href=`${universeLink(universe.shortname)}` ) #{universe.title}
-                  td
-                    small #{formatDate(universe.updated_at, true)}
-          script.
-            document.querySelectorAll('.unfollow-link').forEach(el => {
-              el.addEventListener('click', async () => {
-                try {
-                  await putJSON(`/api/universes/${el.dataset.universe}/follow`, { isFollowing: false });
-                  window.location.reload();
-                } catch (err) {
-                  console.error(err);
-                }
+                    td
+                      small #{formatDate(universe.updated_at, true)}
+          .sheet
+            h2 Universes I Follow
+            table.w-100
+              thead
+                th Name
+                th Updated
+              tbody
+                each universe in followedUniverses
+                  tr
+                    td
+                      .d-flex.align-center.gap-1
+                        a.link.d-flex.align-center.unfollow-link( data-universe=universe.shortname )
+                          span.material-symbols-outlined( style={ 'font-size': '1rem' } ) cancel
+                        a.link.link-animated( href=`${universeLink(universe.shortname)}` ) #{universe.title}
+                    td
+                      small #{formatDate(universe.updated_at, true)}
+            script.
+              document.querySelectorAll('.unfollow-link').forEach(el => {
+                el.addEventListener('click', async () => {
+                  try {
+                    await putJSON(`/api/universes/${el.dataset.universe}/follow`, { isFollowing: false });
+                    window.location.reload();
+                  } catch (err) {
+                    console.error(err);
+                  }
+                });
               });
-            });
-      .grow-3.sheet
-        h2 Recent Updates by Others
-        if followedUniverses.length > 0
+        .grow-3.sheet.scroll-x
+          h2 Recent Updates by Others
+          if followedUniverses.length > 0
+            table.w-100
+              thead
+                th Name
+                th Universe
+                th Last updated by
+                th Updated
+              tbody
+                each item in recentlyUpdated
+                  tr
+                    td
+                      a.link.link-animated( href=`${universeLink(item.universe_short)}/items/${item.shortname}` ) #{item.title}
+                      if !item.last_updated_by
+                        small( style='font-size: x-small;' )  (New)
+                    td
+                      small
+                        a.link.link-animated( href=`${universeLink(item.universe_short)}` ) #{item.universe}
+                    td
+                      small
+                        a.link.link-animated( href=`${ADDR_PREFIX}/users/${item.last_updated_by || item.author}` ) #{item.last_updated_by || item.author}
+                    td
+                      small #{formatDate(item.updated_at, true)}
+          else
+            p No updates here — try following some 
+              a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) universes
+              |  first!
+          h2 May Need Review
           table.w-100
             thead
               th Name
               th Universe
-              th Last updated by
               th Updated
             tbody
-              each item in recentlyUpdated
+              each item in oldestUpdated
                 tr
                   td
-                    a.link.link-animated( href=`${universeLink(item.universe_short)}/items/${item.shortname}` ) #{item.title}
-                    if !item.last_updated_by
-                      small( style='font-size: x-small;' )  (New)
+                    .d-flex.gap-1
+                      button.pa-1( onclick=`snooze('${item.universe_short}', '${item.shortname}')` data-item=item.shortname )
+                        small Dismiss
+                      a.link.link-animated( href=`${universeLink(item.universe_short)}/items/${item.shortname}` ) #{item.title}
                   td
                     small
                       a.link.link-animated( href=`${universeLink(item.universe_short)}` ) #{item.universe}
                   td
-                    small
-                      a.link.link-animated( href=`${ADDR_PREFIX}/users/${item.last_updated_by || item.author}` ) #{item.last_updated_by || item.author}
-                  td
                     small #{formatDate(item.updated_at, true)}
-        else
-          p No updates here — try following some 
-            a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) universes
-            |  first!
-        h2 May Need Review
-        table.w-100
-          thead
-            th Name
-            th Universe
-            th Updated
-          tbody
-            each item in oldestUpdated
-              tr
-                td
-                  .d-flex.gap-1
-                    button.pa-1( onclick=`snooze('${item.universe_short}', '${item.shortname}')` data-item=item.shortname )
-                      small Dismiss
-                    a.link.link-animated( href=`${universeLink(item.universe_short)}/items/${item.shortname}` ) #{item.title}
-                td
-                  small
-                    a.link.link-animated( href=`${universeLink(item.universe_short)}` ) #{item.universe}
-                td
-                  small #{formatDate(item.updated_at, true)}

--- a/templates/home.pug
+++ b/templates/home.pug
@@ -134,7 +134,7 @@ block content
               each item in oldestUpdated
                 tr
                   td
-                    .d-flex.gap-1
+                    .d-flex.gap-1.align-center
                       button.pa-1( onclick=`snooze('${item.universe_short}', '${item.shortname}')` data-item=item.shortname )
                         small Dismiss
                       a.link.link-animated( href=`${universeLink(item.universe_short)}/items/${item.shortname}` ) #{item.title}

--- a/templates/home.pug
+++ b/templates/home.pug
@@ -1,6 +1,10 @@
 extends layout.pug
 include mixins.pug
 
+block scripts
+  script
+    include /static/scripts/fetchUtils.js
+
 block content
   script.
     let snoozeTimeout;
@@ -44,6 +48,47 @@ block content
         | to get started!
   else
     .d-flex.gap-1.flex-wrap.align-start
+      .grow-1.d-flex.flex-col.gap-1
+        .sheet
+          h2 My Universes
+          table.w-100
+            thead
+              th Name
+              th Updated
+            tbody
+              each universe in universes
+                tr
+                  td
+                    a.link.link-animated( href=`${universeLink(universe.shortname)}` ) #{universe.title}
+                  td
+                    small #{formatDate(universe.updated_at, true)}
+        .sheet
+          h2 Universes I Follow
+          table.w-100
+            thead
+              th Name
+              th Updated
+            tbody
+              each universe in followedUniverses
+                tr
+                  td
+                    .d-flex.align-center.gap-1
+                      a.link.d-flex.align-center.unfollow-link( data-universe=universe.shortname )
+                        span.material-symbols-outlined( style={ 'font-size': '1rem' } ) cancel
+                      a.link.link-animated( href=`${universeLink(universe.shortname)}` ) #{universe.title}
+                  td
+                    small #{formatDate(universe.updated_at, true)}
+          script.
+            document.querySelectorAll('.unfollow-link').forEach(el => {
+              el.addEventListener('click', async () => {
+                try {
+                  await putJSON(`/api/universes/${el.dataset.universe}/follow`, { isFollowing: false });
+                  window.location.reload();
+                } catch (err) {
+                  console.error(err);
+                }
+              });
+            });
       .grow-3.sheet
         h2 Recent Updates by Others
         if followedUniverses.length > 0
@@ -57,7 +102,7 @@ block content
               each item in recentlyUpdated
                 tr
                   td
-                    a.big-text.link.link-animated( href=`${universeLink(item.universe_short)}/items/${item.shortname}` ) #{item.title}
+                    a.link.link-animated( href=`${universeLink(item.universe_short)}/items/${item.shortname}` ) #{item.title}
                     if !item.last_updated_by
                       small( style='font-size: x-small;' )  (New)
                   td
@@ -85,22 +130,9 @@ block content
                   .d-flex.gap-1
                     button.pa-1( onclick=`snooze('${item.universe_short}', '${item.shortname}')` data-item=item.shortname )
                       small Dismiss
-                    a.big-text.link.link-animated( href=`${universeLink(item.universe_short)}/items/${item.shortname}` ) #{item.title}
+                    a.link.link-animated( href=`${universeLink(item.universe_short)}/items/${item.shortname}` ) #{item.title}
                 td
                   small
                     a.link.link-animated( href=`${universeLink(item.universe_short)}` ) #{item.universe}
                 td
                   small #{formatDate(item.updated_at, true)}
-      .grow-1.d-flex.flex-col.gap-1
-        .sheet
-          h2 My Universes
-          ul
-            each universe in universes
-              li.big-text
-                a.link.link-animated( href=`${universeLink(universe.shortname)}` ) #{universe.title}
-        .sheet
-          h2 Universes I Follow
-          ul
-            each universe in followedUniverses
-              li.big-text
-                a.link.link-animated( href=`${universeLink(universe.shortname)}` ) #{universe.title}

--- a/templates/home.pug
+++ b/templates/home.pug
@@ -1,6 +1,12 @@
 extends layout.pug
 include mixins.pug
 
+block title
+  if !contextUser
+    title Welcome to Archivium!
+  else
+    title Home — Archivium
+
 block scripts
   script
     include /static/scripts/fetchUtils.js

--- a/templates/layout.pug
+++ b/templates/layout.pug
@@ -135,9 +135,8 @@ html(lang='en')
 
     main
       .page
-        if !displayUniverse
-          #breadcrumbs
-            block breadcrumbs
+        #breadcrumbs
+          block breadcrumbs
         block content
 
     footer

--- a/templates/layout.pug
+++ b/templates/layout.pug
@@ -25,7 +25,7 @@ html(lang='en')
     link(rel='stylesheet' href=`${ADDR_PREFIX}/static/assets/styles.css`)
     link(rel='icon' type='image/x-icon' href=`${ADDR_PREFIX}/static/assets/icons/archivium.ico`)
 
-    - const icons  = ['edit', 'add', 'delete', 'settings', 'logout', 'person', 'notifications_active', 'notifications', 'mark_email_unread', 'drafts', 'visibility_off'].sort();
+    - const icons  = ['edit', 'add', 'cancel', 'delete', 'settings', 'logout', 'person', 'notifications_active', 'notifications', 'mark_email_unread', 'drafts', 'visibility_off'].sort();
     link(rel='stylesheet' href=`https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=${icons.join(',')}`)
     style.
       .material-symbols-outlined {

--- a/templates/layout.pug
+++ b/templates/layout.pug
@@ -20,7 +20,8 @@ mixin mdText(tag)
 doctype html
 html(lang='en')
   head
-    title Archivium
+    block title
+      title Archivium
     link(rel='manifest' href='/static/manifest.json')
     link(rel='stylesheet' href=`${ADDR_PREFIX}/static/assets/styles.css`)
     link(rel='icon' type='image/x-icon' href=`${ADDR_PREFIX}/static/assets/icons/archivium.ico`)

--- a/templates/list/contacts.pug
+++ b/templates/list/contacts.pug
@@ -1,6 +1,9 @@
 extends ../layout.pug
 include ../mixins.pug
 
+block title
+  title Contacts — Archivium
+
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
   |  / 

--- a/templates/list/items.pug
+++ b/templates/list/items.pug
@@ -10,6 +10,11 @@ block scripts
     include /static/scripts/listUtils.js
     include /static/scripts/searchUtils.js
 
+block breadcrumbs
+  a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
+  |  / 
+  span #{T('Items')}
+
 block content
   h1.center Items
   .d-flex.align-center

--- a/templates/list/items.pug
+++ b/templates/list/items.pug
@@ -1,6 +1,9 @@
 extends ../layout.pug
 include ../mixins.pug
 
+block title
+  title Items — Archivium
+
 block scripts
   script
     include /static/scripts/cardUtils.js

--- a/templates/list/notes.pug
+++ b/templates/list/notes.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title Notes — Archivium
+
 block styles
   link( rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css" )
 

--- a/templates/list/search.pug
+++ b/templates/list/search.pug
@@ -1,6 +1,9 @@
 extends ../layout.pug
 include ../mixins.pug
 
+block title
+  title Search — Archivium
+
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
   |  / 

--- a/templates/list/universeItems.pug
+++ b/templates/list/universeItems.pug
@@ -2,8 +2,13 @@ extends ../layout.pug
 include ../mixins.pug
 
 block title
-  title Items — #{universe.title}
-
+  title
+    if type
+      | #{capitalize(T(`${((universe.obj_data.cats || {})[type] || [, 'Missing Category'])[1]}`))} 
+    else
+      | Items 
+    | of #{universe.title}
+    
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
   |  / 
@@ -11,7 +16,10 @@ block breadcrumbs
   |  / 
   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
   |  / 
-  span #{T('Items')}
+  if type
+    | #{capitalize(T(`${((universe.obj_data.cats || {})[type] || [, 'Missing Category'])[1]}`))}
+  else
+    | #{T('Items')}
 
 block content
   script
@@ -22,7 +30,7 @@ block content
 
   h1.center 
     if type
-      | #{capitalize(T(`${((universe.obj_data.cats || {})[type] || [, 'Missing type items'])[1]}`))} 
+      | #{capitalize(T(`${((universe.obj_data.cats || {})[type] || [, 'Missing Category'])[1]}`))} 
     else
       | Items 
     | of #{universe.title}

--- a/templates/list/universeItems.pug
+++ b/templates/list/universeItems.pug
@@ -1,6 +1,9 @@
 extends ../layout.pug
 include ../mixins.pug
 
+block title
+  title Items — #{universe.title}
+
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
   |  / 

--- a/templates/list/universeItems.pug
+++ b/templates/list/universeItems.pug
@@ -10,11 +10,14 @@ block title
     | of #{universe.title}
     
 block breadcrumbs
-  a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
+  if displayUniverse
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{universe.title}
+  else
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
   |  / 
   if type
     | #{capitalize(T(`${((universe.obj_data.cats || {})[type] || [, 'Missing Category'])[1]}`))}

--- a/templates/list/universes.pug
+++ b/templates/list/universes.pug
@@ -27,7 +27,6 @@ block content
     select( id='sort_order' name='sort_order' )
       option( value='desc' ) Descending
       option( value='asc' ) Ascending
-    a.link.link-animated( href=`${ADDR_PREFIX}/universes/create` ) Create New
     .grow-1
     form.flex-row.gap-0
       input( id='search' name='search' value=search placeholder='Search...' )

--- a/templates/list/universes.pug
+++ b/templates/list/universes.pug
@@ -1,6 +1,9 @@
 extends ../layout.pug
 include ../mixins.pug
 
+block title
+  title Universes — Archivium
+
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
   |  / 

--- a/templates/login.pug
+++ b/templates/login.pug
@@ -1,5 +1,8 @@
 extends layout.pug
 
+block title
+  title Login to Archivium
+
 block content
   h2 Login
   form#login( method='post' )

--- a/templates/signup.pug
+++ b/templates/signup.pug
@@ -1,5 +1,8 @@
 extends layout.pug
 
+block title
+  title Create Account — Archivium
+
 block scripts
   script( src='https://www.google.com/recaptcha/api.js' )
   script.

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -39,9 +39,11 @@ block breadcrumbs
 
 block content
   .d-flex.justify-center
-    .sheet.mt-8.px-8.py-4( style={ 'background-color': item.itemTypeColor } )
+    .sheet.mt-8.px-8.py-4( style={ 'background-color': item.itemTypeColor, 'min-width': '15vw' } )
       h1.center.ma-0 #{item.title}
-      p.center.ma-0 #{capitalize(T(item.itemTypeName))} of #{item.universe}
+      p.center.ma-0 #{capitalize(T(item.itemTypeName))}
+        if !displayUniverse
+          |  of #{item.universe}
   p.center.mb-2
     small Created by 
       if item.author

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -30,14 +30,15 @@ block breadcrumbs
   |  / 
   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
   |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/items` ) #{T('Items')}
+  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/items?type=${item.item_type}` ) #{capitalize(T(`${((universe.obj_data.cats || {})[item.item_type] || [, 'Missing Category'])[1]}`))}
   |  / 
   span #{item.title}
 
 block content
-  h1.center #{item.title}
-  p.center #{capitalize(T(item.itemTypeName))} of 
-    a.link.link-animated( href=`${universeLink(universe.shortname)}/` ) #{item.universe}
+  .d-flex.justify-center
+    .sheet.mt-8.px-8.py-4( style={ 'background-color': item.itemTypeColor } )
+      h1.center.ma-0 #{item.title}
+      p.center.ma-0 #{capitalize(T(item.itemTypeName))} of #{item.universe}
   p.center.mb-2
     small Created by 
       if item.author

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title #{item.title}
+
 block append styles
   link( rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css" )
 

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -24,11 +24,14 @@ block scripts
     //- include /static/scripts/editor/rich.js
 
 block breadcrumbs
-  a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
+  if displayUniverse
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{universe.title}
+  else
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
   |  / 
   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}/items?type=${item.item_type}` ) #{capitalize(T(`${((universe.obj_data.cats || {})[item.item_type] || [, 'Missing Category'])[1]}`))}
   |  / 

--- a/templates/view/markdownDemo.pug
+++ b/templates/view/markdownDemo.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title #{title || T('Markdown Demo')}
+
 block styles
   link( rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css" )
 

--- a/templates/view/notifications.pug
+++ b/templates/view/notifications.pug
@@ -1,6 +1,9 @@
 extends ../layout.pug
 include ../mixins.pug
 
+block title
+  title Notifications — Archivium
+
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
   |  / 

--- a/templates/view/privateUniverse.pug
+++ b/templates/view/privateUniverse.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title Access Denied
+
 block scripts
   script 
     include /static/scripts/domUtils.js

--- a/templates/view/universe.pug
+++ b/templates/view/universe.pug
@@ -16,11 +16,12 @@ mixin typeCard(shortname, category)
         a.cardBtn.link( href=`${ADDR_PREFIX}/items?author=${contextUser.username}&universe=${universe.shortname}${shortname ? `&type=${shortname}` : ''}` ) My #{shortname ? category[1] : 'Items'}
 
 block breadcrumbs
-  a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
-  |  / 
-  span #{universe.title}
+  if !displayUniverse  
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
+    |  / 
+    span #{universe.title}
 
 block scripts
   script

--- a/templates/view/universe.pug
+++ b/templates/view/universe.pug
@@ -6,7 +6,7 @@ block title
 
 mixin typeCard(shortname, category)
   .card.item-type
-    a.cardLink.link( href=`${universeLink(universe.shortname)}/items${shortname ? `?type=${shortname}` : ''}` )
+    a.cardLink( href=`${universeLink(universe.shortname)}/items${shortname ? `?type=${shortname}` : ''}` )
       div(style={ 'background-color': shortname ? category[2] : '#f3f3f3' })
         h2.mb-0(align='center')= shortname ? capitalize(category[1]) : T('All Items')
         h2.mt-0(align='center') (#{counts[shortname] || 0})

--- a/templates/view/universe.pug
+++ b/templates/view/universe.pug
@@ -1,6 +1,9 @@
 extends ../layout.pug
 include ../mixins.pug
 
+block title
+  title #{universe.title}
+
 mixin typeCard(shortname, category)
   .card.item-type
     a.cardLink.link( href=`${universeLink(universe.shortname)}/items${shortname ? `?type=${shortname}` : ''}` )

--- a/templates/view/universeThread.pug
+++ b/templates/view/universeThread.pug
@@ -1,5 +1,8 @@
 extends ../layout.pug
 
+block title
+  title #{thread-title} — #{universe.title}
+
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
   |  / 
@@ -9,7 +12,7 @@ block breadcrumbs
   |  / 
   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}?tab=discuss` ) #{T('Discuss')}
   |  / 
-  span #{T('New')}
+  span #{thread.title}
 
 block scripts
   script

--- a/templates/view/universeThread.pug
+++ b/templates/view/universeThread.pug
@@ -4,11 +4,14 @@ block title
   title #{thread.title} — #{universe.title}
 
 block breadcrumbs
-  a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
-  |  / 
-  a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
+  if displayUniverse
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{universe.title}
+  else
+    a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes` ) #{T('Universes')}
+    |  / 
+    a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}` ) #{universe.title}
   |  / 
   a.link.link-animated( href=`${ADDR_PREFIX}/universes/${universe.shortname}?tab=discuss` ) #{T('Discuss')}
   |  / 

--- a/templates/view/universeThread.pug
+++ b/templates/view/universeThread.pug
@@ -1,7 +1,7 @@
 extends ../layout.pug
 
 block title
-  title #{thread-title} — #{universe.title}
+  title #{thread.title} — #{universe.title}
 
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}

--- a/templates/view/user.pug
+++ b/templates/view/user.pug
@@ -1,6 +1,9 @@
 extends ../layout.pug
 include ../mixins.pug
 
+block title
+  title #{user.username} on Archivium
+
 block breadcrumbs
   a.link.link-animated( href=`${ADDR_PREFIX}/` ) #{T('Home')}
   |  / 

--- a/views/pages/item.js
+++ b/views/pages/item.js
@@ -62,6 +62,7 @@ module.exports = {
     }
     item.obj_data = JSON.parse(item.obj_data);
     item.itemTypeName = ((universe.obj_data.cats ?? {})[item.item_type] ?? ['missing_cat'])[0];
+    item.itemTypeColor = ((universe.obj_data.cats ?? {})[item.item_type] ?? [,,'#f3f3f3'])[2];
     if (item.gallery.length > 0) {
       item.gallery = item.gallery.sort((a, b) => a.id > b.id ? 1 : -1);
     }


### PR DESCRIPTION
closes #67, closes #128, closes #153, closes #159, closes #161,  closes #143

- Add a "go back" button to the edit permissions page
- Fix navbar not conforming to font height
- Fix lists not having the correct indentation on mobile
- New, more compact layout for home page:
![image](https://github.com/user-attachments/assets/51cdb055-e032-476e-b91e-cb03cdee2e1a)
![image](https://github.com/user-attachments/assets/4f8563c8-3e24-4e64-ab41-74f60a3f107c)
- Propely size box shadows (such as for cards and sheets) on mobile
- If the home page overflows even after all the fixes, scroll the review/updates card internally
- Change how item types are displayed (in the breadcrumbs, + a new colorful blurb)
![image](https://github.com/user-attachments/assets/7aac3415-2372-4df6-b74e-348c145318f2)
- Fix breadcrumbs in display universes (custom domains)
- Add "new item" button to the top of item list, and change Create Universe link to be a similar button
![image](https://github.com/user-attachments/assets/b141a39f-17d4-43e1-be50-78d443dcf2cf)
- Make the Create Item page reflect what item type is currently selected, and change dynamically
- Add missing breadcumbs to `/items` page
- Improve hover animation for cards (move them upwards slightly)